### PR TITLE
WEBSDK-12 stop caching link_id on sendSMS

### DIFF
--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1019,7 +1019,6 @@ Branch.prototype['sendSMS'] = wrap(
 							if (err) {
 								return done(err);
 							}
-							self._storage.set('click_id', data['click_id']);
 							sendSMS(data['click_id']);
 						}
 					);


### PR DESCRIPTION
Caching link_id when creating a new link for sendSMS was causing updated linkData to not be sent in the sms. Removing this cache will make sure a new link is created with updated data each time unless there is referring_link data available due to coming from to the page from a branch link click.  referring_link data can be overridden by setting 'make_new_link' to true when passing in options to the sendSMS() function.

@jsaleigh 