### PR TITLE
INTENG-2844 Make merge and iframe more defensive

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -217,7 +217,10 @@ utils.processReferringLink = function(link) {
  * @param {Object} from
  */
 utils.merge = function(to, from) {
-	if (typeof from === 'undefined') {
+	if (!to || typeof to !== 'object') {
+		to = {};
+	}
+	if (!from || typeof from !== 'object') {
 		return to;
 	}
 

--- a/src/2_session.js
+++ b/src/2_session.js
@@ -39,7 +39,10 @@ session.set = function(storage, data, first) {
  * @param {Object} newData
  */
 session.update = function(storage, newData) {
-	var currentData = session.get(storage);
+	if (!newData) {
+		return;
+	}
+	var currentData = session.get(storage) || {};
 	var data = utils.merge(currentData, newData);
 	storage.set('branch_session', goog.json.serialize(data));
 };

--- a/src/5_banner.js
+++ b/src/5_banner.js
@@ -130,11 +130,22 @@ banner = function(branch, options, linkData, storage) {
 			};
 		}
 	}
-	else {
+	else if (doc.getElementById('sms-form')) {
 		doc.getElementById('sms-form').addEventListener('submit', function(ev) {
 			ev.preventDefault();
 			sendSMS(doc, branch, options, linkData);
 		});
+	}
+	else {
+		element.onload = function() {
+			doc = element.contentWindow.document;
+			if (doc.getElementById('sms-form')) {
+				doc.getElementById('sms-form').addEventListener('submit', function(ev) {
+					ev.preventDefault();
+					sendSMS(doc, branch, options, linkData);
+				});
+			}
+		};
 	}
 
 	var bodyMarginTopComputed = banner_utils.getBodyStyle('margin-top');

--- a/test/1_utils.js
+++ b/test/1_utils.js
@@ -30,6 +30,28 @@ describe('utils', function() {
 			};
 			assert.deepEqual(utils.merge(obj1, obj2), expectedMerged, 'Correctly merged');
 		});
+		it('should handle an non-object for first argument', function() {
+			var obj1 = null;
+			var obj2 = {
+				"simple": "object",
+				"nested": {
+					"object": "here"
+				}
+			};
+			var expectedMerged = {
+				"simple": "object",
+				"nested": {
+					"object": "here"
+				}
+			};
+			assert.deepEqual(utils.merge(obj1, obj2), expectedMerged, 'Correctly merged');
+		});
+		it('should handle an non-object for second argument', function() {
+			var obj1 = { "simple": "object" };
+			var obj2 = null;
+			var expectedMerged = { "simple": "object" };
+			assert.deepEqual(utils.merge(obj1, obj2), expectedMerged, 'Correctly merged');
+		});
 	});
 
 	describe('whiteListSessionData', function() {


### PR DESCRIPTION
utils.merge was causing an error if one of the arguments was passing in `null`.
 
smartbanner was occasionally unable to attach the sendSMS call to action. This change makes sure that the iframe has loaded before trying to attach the event listener.