### PR TITLE
Allow both meta name and property to be in applinks metadata

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -473,7 +473,6 @@ utils.scrapeOpenGraphContent = function(property, content) {
  */
 utils.scrapeHostedDeepLinkData = function() {
 	var params = {};
-
 	var metas = document.getElementsByTagName('meta');
 
 	for (var i = 0; i < metas.length; i++) {
@@ -481,22 +480,22 @@ utils.scrapeHostedDeepLinkData = function() {
 			continue;
 		}
 
-		if (metas[i].getAttribute('name')) {
-			var name = metas[i].getAttribute('name');
-			var split = name.split(':');
+		var name = metas[i].getAttribute('name');
+		var property = metas[i].getAttribute('property');
+		// name takes precendence over propery
+		var nameOrProperty = name || property;
+
+		if (nameOrProperty === 'al:ios:url') {
+			params['$ios_deeplink_path'] = utils.extractMobileDeeplinkPath(metas[i].getAttribute('content'));
+		}
+		else if (nameOrProperty === 'al:android:url') {
+			params['$android_deeplink_path'] = utils.extractMobileDeeplinkPath(metas[i].getAttribute('content'));
+		}
+		else {
+			var split = nameOrProperty.split(':');
 
 			if ((split.length === 3) && (split[0] === 'branch') && (split[1] === 'deeplink')) {
 				params[split[2]] = metas[i].getAttribute('content');
-			}
-		}
-		else if (metas[i].getAttribute('property')) {
-			var property = metas[i].getAttribute('property');
-
-			if (property === 'al:ios:url') {
-				params['$ios_deeplink_path'] = utils.extractMobileDeeplinkPath(metas[i].getAttribute('content'));
-			}
-			else if (property === 'al:android:url') {
-				params['$android_deeplink_path'] = utils.extractMobileDeeplinkPath(metas[i].getAttribute('content'));
 			}
 		}
 	}

--- a/test/1_utils.js
+++ b/test/1_utils.js
@@ -384,4 +384,26 @@ describe('utils', function() {
 			}
 		});
 	});
+	describe('scrapeHostedDeepLinkData', function() {
+		it('should return an object', function() {
+			assert.strictEqual(
+				'object',
+				typeof utils.scrapeHostedDeepLinkData(),
+				'should return an object type'
+			);
+		});
+		it('should find applink and branch hosted data on page', function() {
+			var expected = {
+				productId: '1234',
+				productName: 'shoes',
+				$ios_deeplink_path: 'monster/view/ios',
+				$android_deeplink_path: 'monster/view/android'
+			};
+			assert.deepEqual(
+				expected,
+				utils.scrapeHostedDeepLinkData(),
+				'should return an object with data'
+			);
+		});
+	});
 });

--- a/test/test.html
+++ b/test/test.html
@@ -2,6 +2,12 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="branch:deeplink:productId" content="1234" />
+	<meta name="branch:deeplink:productName" content="shoes" /> -->
+
+	<meta property="al:ios:url" content="applinks://monster/view/ios" data-app>
+	<meta property="android" name="al:android:url" content="applinks://monster/view/android" data-app>
+
 	<title>Tests for Branch</title>
 </head>
 <body>


### PR DESCRIPTION
This change accounts for sites that include both a property and name in their app links meta tags.

`<meta name="test" property="test" content="test-content">`

@jsaleigh 