### PR TITLE
JOUR-656 - Update Journeys test url behavior

### DIFF
--- a/src/branch_view.js
+++ b/src/branch_view.js
@@ -46,7 +46,7 @@ function renderHtmlBlob(parent, html, hasApp) {
  * @param {Object} storage
  * @param {Boolean} hasApp
  */
-branch_view.handleBranchViewData = function(server, branchViewData, requestData, storage, hasApp) {
+branch_view.handleBranchViewData = function(server, branchViewData, requestData, storage, hasApp, testFlag) {
 	var banner = null;
 	var cta = null;
 
@@ -77,7 +77,9 @@ branch_view.handleBranchViewData = function(server, branchViewData, requestData,
 			var failed = false;
 			if (!error && html) {
 
-				var hideBanner = journeys_utils.findDismissPeriod(html);
+				var hideBanner = !testFlag
+					? journeys_utils.findDismissPeriod(html)
+					: 0;
 
 				var timeoutTrigger = window.setTimeout(
 					function() {


### PR DESCRIPTION
Updates to test url behavior:

- no longer show journeys banner on desktop test
- enable CTA and hideBanner buttons
- Add testFlag. Refreshing page will show test banner again even if hide banner is set for a longer period of time
- remove unnecessary handleBranchView() call in v1/open callback. v1/event returns branchViewData, not v1/open

Reviewer: @jsaleigh 