### PR TITLE
Auto App Index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ src/5_banner.js\
 src/6_branch.js\
 src/7_initialization.js\
 src/branch_view.js\
-src/journeys_utils.js
+src/journeys_utils.js\
+src/appindexing.js
 
 EXTERN=src/extern.js
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ ___
   + [.setBranchViewData()](#setBranchViewData)
   + [.banner()](#banneroptions-data)
 
+7. Firebase App Indexing
+  + [.autoAppIndex()](#autoAppIndex-callback)
+
 ___
 # Global
 
@@ -917,6 +920,56 @@ closing the banner is very simple by calling `Branch.closeBanner()`.
 ```js
 branch.closeBanner();
 ```
+
+
+
+### autoAppIndex(data, callback) 
+
+**Parameters**
+
+**data**: `Object`, _optional_ - Information on how to build your App Indexing tags for your webpage
+
+**callback**: `function`, _optional_ - Returns an error string if unsuccessful
+
+This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage. 
+Once inserted, these tags will help Google index and surface content from your App in Google Search.
+
+Listed below are optional parameters which can be used to build your page's App Indexing Tags:
+
+| Key | Value
+| --- | ---
+| "androidPackageName" | Android App's package name
+| "androidURL" | A custom scheme for your Android App such as: 'example/home/cupertino/12345' where 'example' is the App's URI scheme and 'home/cupertino/12345' routes to unique content the App
+| "iosAppStoreId" | iTunes App Store ID for your iOS App 
+| "iosURL" | A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
+
+Resultant Firebase App Indexing tags will have the following format:
+
+<link rel="alternate" href="androidapp://{androidPackageName}/{androidURL}?{branch_tracking_params}"/>
+<link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params}"/>
+
+Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
+Also, if optional parameters are specified but Firebase App Indexing tags already exist then, Branch will ignore them and append Branch tracking params to the end of the existing tags.
+
+Analytics related to Google's attempts to index your App via this method can be found from Source Analytics in Dashboard where 'channel' equals 'Firebase App Indexing' and 'feature' equals 'Auto App Indexing'.
+
+##### Usage
+```js
+branch.autoAppIndex(
+    data,
+    callback (err)
+);
+```
+##### Example
+```js 
+branch.autoAppIndex({ 
+    iosAppId:'123456789',
+    iosURL:'example/home/cupertino/12345',
+    androidPackageName:'com.somecompany.app',
+    androidURL:'example/home/cupertino/12345'
+}, function(err) { console.log(err); });
+```
+___
 
 
 

--- a/README.md
+++ b/README.md
@@ -931,7 +931,7 @@ branch.closeBanner();
 
 **callback**: `function`, _optional_ - Returns an error string if unsuccessful
 
-This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage. 
+This function generates and inserts Firebase App Indexing tags between the `<head></head>` section of your webpage.
 Once inserted, these tags will help Google index and surface content from your App in Google Search.
 
 Listed below are optional parameters which can be used to build your page's App Indexing Tags:
@@ -939,19 +939,20 @@ Listed below are optional parameters which can be used to build your page's App 
 | Key | Value
 | --- | ---
 | "androidPackageName" | Android App's package name
-| "androidURL" | A custom scheme for your Android App such as: 'example/home/cupertino/12345' where 'example' is the App's URI scheme and 'home/cupertino/12345' routes to unique content the App
-| "iosAppStoreId" | iTunes App Store ID for your iOS App 
-| "iosURL" | A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
+| "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content the App
+| "iosAppStoreId" | iTunes App Store ID for your iOS App
+| "iosURL" | A custom scheme for your iOS App such as: `example/home/cupertino/12345`
+| "data" | Any additional deep link data that you would like to pass to your App.
 
 Resultant Firebase App Indexing tags will have the following format:
-
-<link rel="alternate" href="androidapp://{androidPackageName}/{androidURL}?{branch_tracking_params}"/>
-<link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params}"/>
-
+```
+<link rel="alternate" href="android-app://{androidPackageName}/{androidURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
+<link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
+```
 Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
-Also, if optional parameters are specified but Firebase App Indexing tags already exist then, Branch will ignore them and append Branch tracking params to the end of the existing tags.
+Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch will append Branch tracking params to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
 
-Analytics related to Google's attempts to index your App via this method can be found from Source Analytics in Dashboard where 'channel' equals 'Firebase App Indexing' and 'feature' equals 'Auto App Indexing'.
+Analytics related to Google's attempts to index your App's content via this method can be found from Source Analytics in Dashboard where `channel` is `Firebase App Indexing` and `feature` is `Auto App Indexing`.
 
 ##### Usage
 ```js
@@ -961,14 +962,14 @@ branch.autoAppIndex(
 );
 ```
 ##### Example
-```js 
-branch.autoAppIndex({ 
+```js
+branch.autoAppIndex({
     iosAppId:'123456789',
     iosURL:'example/home/cupertino/12345',
     androidPackageName:'com.somecompany.app',
-    androidURL:'example/home/cupertino/12345'
+    androidURL:'example/home/cupertino/12345',
+    data:{"walkScore":62, "transitScore":62}
 }, function(err) { console.log(err); });
-```
 ___
 
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ ___
   + [.banner()](#banneroptions-data)
 
 7. Firebase App Indexing
-  + [.autoAppIndex()](#autoAppIndex-callback)
+  + [.autoAppIndex()](#autoappindex)
 
 ___
 # Global
@@ -968,8 +968,9 @@ branch.autoAppIndex({
     iosURL:'example/home/cupertino/12345',
     androidPackageName:'com.somecompany.app',
     androidURL:'example/home/cupertino/12345',
-    data:{"walkScore":62, "transitScore":62}
+    data:{"walkScore":65, "transitScore":50}
 }, function(err) { console.log(err); });
+```
 ___
 
 

--- a/README.md
+++ b/README.md
@@ -939,10 +939,10 @@ Listed below are optional parameters which can be used to build your page's App 
 | Key | Value
 | --- | ---
 | "androidPackageName" | Android App's package name
-| "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content the App
+| "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content in the App
 | "iosAppStoreId" | iTunes App Store ID for your iOS App
 | "iosURL" | A custom scheme for your iOS App such as: `example/home/cupertino/12345`
-| "data" | Any additional deep link data that you would like to pass to your App.
+| "data" | Any additional deep link data that you would like to pass to your App
 
 Resultant Firebase App Indexing tags will have the following format:
 ```
@@ -950,7 +950,7 @@ Resultant Firebase App Indexing tags will have the following format:
 <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
 ```
 Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
-Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch will append Branch tracking params to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
+Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch tracking params will be appended to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
 
 Analytics related to Google's attempts to index your App's content via this method can be found from Source Analytics in Dashboard where `channel` is `Firebase App Indexing` and `feature` is `Auto App Indexing`.
 

--- a/docs/web/2_table_of_contents.md
+++ b/docs/web/2_table_of_contents.md
@@ -27,4 +27,7 @@
   + [.setBranchViewData()](#setBranchViewData)
   + [.banner()](#banneroptions-data)
 
+7. Firebase App Indexing
+  + [.autoAppIndex()](#autoAppIndex-callback)
+
 ___

--- a/docs/web/2_table_of_contents.md
+++ b/docs/web/2_table_of_contents.md
@@ -28,6 +28,6 @@
   + [.banner()](#banneroptions-data)
 
 7. Firebase App Indexing
-  + [.autoAppIndex()](#autoAppIndex-callback)
+  + [.autoAppIndex()](#autoappindex)
 
 ___

--- a/docs/web/3_branch_web.md
+++ b/docs/web/3_branch_web.md
@@ -823,7 +823,7 @@ branch.closeBanner();
 
 **callback**: `function`, _optional_ - Returns an error string if unsuccessful
 
-This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage. 
+This function generates and inserts Firebase App Indexing tags between the `<head></head>` section of your webpage.
 Once inserted, these tags will help Google index and surface content from your App in Google Search.
 
 Listed below are optional parameters which can be used to build your page's App Indexing Tags:
@@ -831,19 +831,20 @@ Listed below are optional parameters which can be used to build your page's App 
 | Key | Value
 | --- | ---
 | "androidPackageName" | Android App's package name
-| "androidURL" | A custom scheme for your Android App such as: 'example/home/cupertino/12345' where 'example' is the App's URI scheme and 'home/cupertino/12345' routes to unique content the App
-| "iosAppStoreId" | iTunes App Store ID for your iOS App 
-| "iosURL" | A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
+| "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content the App
+| "iosAppStoreId" | iTunes App Store ID for your iOS App
+| "iosURL" | A custom scheme for your iOS App such as: `example/home/cupertino/12345`
+| "data" | Any additional deep link data that you would like to pass to your App.
 
 Resultant Firebase App Indexing tags will have the following format:
-
-<link rel="alternate" href="androidapp://{androidPackageName}/{androidURL}?{branch_tracking_params}"/>
-<link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params}"/>
-
+```
+<link rel="alternate" href="android-app://{androidPackageName}/{androidURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
+<link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
+```
 Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
-Also, if optional parameters are specified but Firebase App Indexing tags already exist then, Branch will ignore them and append Branch tracking params to the end of the existing tags.
+Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch will append Branch tracking params to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
 
-Analytics related to Google's attempts to index your App via this method can be found from Source Analytics in Dashboard where 'channel' equals 'Firebase App Indexing' and 'feature' equals 'Auto App Indexing'.
+Analytics related to Google's attempts to index your App's content via this method can be found from Source Analytics in Dashboard where `channel` is `Firebase App Indexing` and `feature` is `Auto App Indexing`.
 
 ##### Usage
 ```js
@@ -853,14 +854,14 @@ branch.autoAppIndex(
 );
 ```
 ##### Example
-```js 
-branch.autoAppIndex({ 
+```js
+branch.autoAppIndex({
     iosAppId:'123456789',
     iosURL:'example/home/cupertino/12345',
     androidPackageName:'com.somecompany.app',
-    androidURL:'example/home/cupertino/12345'
+    androidURL:'example/home/cupertino/12345',
+    data:{"walkScore":62, "transitScore":62}
 }, function(err) { console.log(err); });
-```
 ___
 
 

--- a/docs/web/3_branch_web.md
+++ b/docs/web/3_branch_web.md
@@ -831,10 +831,10 @@ Listed below are optional parameters which can be used to build your page's App 
 | Key | Value
 | --- | ---
 | "androidPackageName" | Android App's package name
-| "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content the App
+| "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content in the App
 | "iosAppStoreId" | iTunes App Store ID for your iOS App
 | "iosURL" | A custom scheme for your iOS App such as: `example/home/cupertino/12345`
-| "data" | Any additional deep link data that you would like to pass to your App.
+| "data" | Any additional deep link data that you would like to pass to your App
 
 Resultant Firebase App Indexing tags will have the following format:
 ```
@@ -842,7 +842,7 @@ Resultant Firebase App Indexing tags will have the following format:
 <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
 ```
 Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
-Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch will append Branch tracking params to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
+Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch tracking params will be appended to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
 
 Analytics related to Google's attempts to index your App's content via this method can be found from Source Analytics in Dashboard where `channel` is `Firebase App Indexing` and `feature` is `Auto App Indexing`.
 

--- a/docs/web/3_branch_web.md
+++ b/docs/web/3_branch_web.md
@@ -860,8 +860,9 @@ branch.autoAppIndex({
     iosURL:'example/home/cupertino/12345',
     androidPackageName:'com.somecompany.app',
     androidURL:'example/home/cupertino/12345',
-    data:{"walkScore":62, "transitScore":62}
+    data:{"walkScore":65, "transitScore":50}
 }, function(err) { console.log(err); });
+```
 ___
 
 

--- a/docs/web/3_branch_web.md
+++ b/docs/web/3_branch_web.md
@@ -815,6 +815,56 @@ branch.closeBanner();
 
 
 
+### autoAppIndex(data, callback) 
+
+**Parameters**
+
+**data**: `Object`, _optional_ - Information on how to build your App Indexing tags for your webpage
+
+**callback**: `function`, _optional_ - Returns an error string if unsuccessful
+
+This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage. 
+Once inserted, these tags will help Google index and surface content from your App in Google Search.
+
+Listed below are optional parameters which can be used to build your page's App Indexing Tags:
+
+| Key | Value
+| --- | ---
+| "androidPackageName" | Android App's package name
+| "androidURL" | A custom scheme for your Android App such as: 'example/home/cupertino/12345' where 'example' is the App's URI scheme and 'home/cupertino/12345' routes to unique content the App
+| "iosAppStoreId" | iTunes App Store ID for your iOS App 
+| "iosURL" | A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
+
+Resultant Firebase App Indexing tags will have the following format:
+
+<link rel="alternate" href="androidapp://{androidPackageName}/{androidURL}?{branch_tracking_params}"/>
+<link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params}"/>
+
+Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
+Also, if optional parameters are specified but Firebase App Indexing tags already exist then, Branch will ignore them and append Branch tracking params to the end of the existing tags.
+
+Analytics related to Google's attempts to index your App via this method can be found from Source Analytics in Dashboard where 'channel' equals 'Firebase App Indexing' and 'feature' equals 'Auto App Indexing'.
+
+##### Usage
+```js
+branch.autoAppIndex(
+    data,
+    callback (err)
+);
+```
+##### Example
+```js 
+branch.autoAppIndex({ 
+    iosAppId:'123456789',
+    iosURL:'example/home/cupertino/12345',
+    androidPackageName:'com.somecompany.app',
+    androidURL:'example/home/cupertino/12345'
+}, function(err) { console.log(err); });
+```
+___
+
+
+
 
 * * *
 

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1752,7 +1752,7 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * @param {string} androidPackageName - _optional_ - Android App's package name
  * @param {string} androidURL - _optional_ - A custom scheme for your Android App such as: 'example/home/cupertino/12345' where 'example' is the App's URI scheme and 'home/cupertino/12345' routes to unique content the App
  * @param {string} iosAppStoreId - _optional_ - iTunes App Store ID for your iOS App 
- * @param {string} iosUrl - _optional_ - A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
+ * @param {string} iosURL - _optional_ - A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
  * @param {function(?Error)=} callback - _optional_ - Returns an error if unsuccessful
  *
  * This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage. 
@@ -1761,7 +1761,7 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * Resultant Firebase App Indexing tags will have the following format:
  *
  * <link rel="alternate" href="androidapp://{androidPackageName}/{androidURL}?{branch_tracking_params}"/>
- * <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosUrl}?{branch_tracking_params}"/>
+ * <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params}"/>
  *
  * Note: If optional parameters above are not specified then Branch will try to build App Indexing tags using your webpage's App Links tags.
  * Also, if optional parameters are specified but App Indexing tags are already present on the webpage then, Branch will ignore what is passed into .autoAppIndex() 
@@ -1780,7 +1780,7 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * ```js
  * branch.autoAppIndex({ 
  *     iosAppId:'123456789',
- *     iosUrl:'example/home/cupertino/12345',
+ *     iosURL:'example/home/cupertino/12345',
  *     androidPackageName:'com.somecompany.app',
  *     androidURL:'example/home/cupertino/12345'
  * }, function(err) { console.log(err); });

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -3,7 +3,6 @@
  */
 'use strict';
 goog.provide('Branch');
-
 goog.require('goog.json'); // jshint unused:false
 goog.require('utils');
 goog.require('resources');
@@ -15,6 +14,7 @@ goog.require('session');
 goog.require('config');
 goog.require('safejson');
 goog.require('branch_view');
+goog.require('appindexing');
 
 /*globals Ti, BranchStorage, require */
 
@@ -1745,3 +1745,74 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
 	});
 	done();
 });
+
+/**
+ * @function Branch.autoAppIndex
+ *
+ * @param {string} androidPackageName - _optional_ - Android App's package name
+ * @param {string} androidURL - _optional_ - A custom scheme for your Android App such as: 'example/home/cupertino/12345' where 'example' is the App's URI scheme and 'home/cupertino/12345' routes to unique content the App
+ * @param {string} iosAppStoreId - _optional_ - iTunes App Store ID for your iOS App 
+ * @param {string} iosUrl - _optional_ - A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
+ * @param {function(?Error)=} callback - _optional_ - Returns an error if unsuccessful
+ *
+ * This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage. 
+ * Once inserted, these tags will help Google to index and surface content from your App in Google Search.
+ * 
+ * Resultant Firebase App Indexing tags will have the following format:
+ *
+ * <link rel="alternate" href="androidapp://{androidPackageName}/{androidURL}?{branch_tracking_params}"/>
+ * <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosUrl}?{branch_tracking_params}"/>
+ *
+ * Note: If optional parameters above are not specified then Branch will try to build App Indexing tags using your webpage's App Links tags.
+ * Also, if optional parameters are specified but App Indexing tags are already present on the webpage then, Branch will ignore what is passed into .autoAppIndex() 
+ * and append Branch tracking params to the end of the existing tags.
+ *
+ * Analytics related to Google's attempts to index your App via this method can be found from Source Analytics in Dashboard where channel is set to 'Firebase-App-Indexing'.
+ *
+ * ##### Usage
+ * ```js
+ * branch.autoAppIndex(
+ *     data,
+ *     callback (err)
+ * );
+ *```
+ * ##### Example
+ * ```js
+ * branch.autoAppIndex({ 
+ *     iosAppId:'123456789',
+ *     iosUrl:'example/home/cupertino/12345',
+ *     androidPackageName:'com.somecompany.app',
+ *     androidURL:'example/home/cupertino/12345'
+ * }, function(err) { console.log(err); });
+ *```
+ *
+ * ##### Callback Format
+ * ```js
+ * callback(
+ *      "Error message"
+ * );
+ * ```
+ * ___
+ */
+/*** +TOC_HEADING &Firebase App Indexing& ^ALL ***/
+/*** +TOC_ITEM #autoAppIndex-callback &.autoAppIndex()& ^ALL ***/
+Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(done, options) {
+	var self = this;
+	options = options || {};
+	appindexing.checkForAppIndexingTags();
+
+	if (appindexing.state['iOSAppIndexingTagsPresent'] === false || appindexing.state['androidAppIndexingTagsPresent'] ===  false) {
+		appindexing.checkOptions(options);
+		if (appindexing.state['androidDetailsComplete'] ===  false) { 
+			appindexing.checkAppLinks('android', options);
+		}
+		if (appindexing.state['iOSDetailsComplete'] === false) {
+			appindexing.checkAppLinks('iOS', options);
+		}
+		if (appindexing.state['iOSDetailsComplete'] === false && appindexing.state['androidDetailsComplete'] === false) {
+			done('Firebase App Indexing tags were not added to your webpage. Please check your configuration.');
+		}
+	}
+	done(null);
+});
+

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1790,12 +1790,13 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  *     iosURL:'example/home/cupertino/12345',
  *     androidPackageName:'com.somecompany.app',
  *     androidURL:'example/home/cupertino/12345',
- *     data:{"walkScore":62, "transitScore":62}
+ *     data:{"walkScore":65, "transitScore":50}
  * }, function(err) { console.log(err); });
+ * ```
  * ___
  */
 /*** +TOC_HEADING &Firebase App Indexing& ^ALL ***/
-/*** +TOC_ITEM #autoAppIndex-callback &.autoAppIndex()& ^ALL ***/
+/*** +TOC_ITEM #autoappindex &.autoAppIndex()& ^ALL ***/
 Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(done, options) {
 	var self = this;
 	options = options || {};

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1546,7 +1546,7 @@ Branch.prototype['removeListener'] = function(listener) {
 function _setBranchViewData(context, done, data) {
 	data = data || {};
 	try {
-		context._branchViewData = JSON.parse(JSON.stringify(data));
+		context._branchViewData = safejson.parse(safejson.stringify(data));
 	}
 	finally {
 		context._branchViewData = context._branchViewData || {};
@@ -1753,7 +1753,7 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * @param {Object} data - _optional_ - Information on how to build your App Indexing tags for your webpage
  * @param {function(?Error)=} callback - _optional_ - Returns an error string if unsuccessful
  *
- * This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage.
+ * This function generates and inserts Firebase App Indexing tags between the `<head></head>` section of your webpage.
  * Once inserted, these tags will help Google index and surface content from your App in Google Search.
  *
  * Listed below are optional parameters which can be used to build your page's App Indexing Tags:
@@ -1761,19 +1761,20 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * | Key | Value
  * | --- | ---
  * | "androidPackageName" | Android App's package name
- * | "androidURL" | A custom scheme for your Android App such as: 'example/home/cupertino/12345' where 'example' is the App's URI scheme and 'home/cupertino/12345' routes to unique content the App
+ * | "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content the App
  * | "iosAppStoreId" | iTunes App Store ID for your iOS App
- * | "iosURL" | A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
+ * | "iosURL" | A custom scheme for your iOS App such as: `example/home/cupertino/12345`
+ * | "data" | Any additional deep link data that you would like to pass to your App.
  *
  * Resultant Firebase App Indexing tags will have the following format:
- *
- * <link rel="alternate" href="androidapp://{androidPackageName}/{androidURL}?{branch_tracking_params}"/>
- * <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params}"/>
- *
+ *```
+ * <link rel="alternate" href="android-app://{androidPackageName}/{androidURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
+ * <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
+ *```
  * Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
- * Also, if optional parameters are specified but Firebase App Indexing tags already exist then, Branch will ignore them and append Branch tracking params to the end of the existing tags.
+ * Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch will append Branch tracking params to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
  *
- * Analytics related to Google's attempts to index your App via this method can be found from Source Analytics in Dashboard where 'channel' equals 'Firebase App Indexing' and 'feature' equals 'Auto App Indexing'.
+ * Analytics related to Google's attempts to index your App's content via this method can be found from Source Analytics in Dashboard where `channel` is `Firebase App Indexing` and `feature` is `Auto App Indexing`.
  *
  * ##### Usage
  * ```js
@@ -1788,9 +1789,9 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  *     iosAppId:'123456789',
  *     iosURL:'example/home/cupertino/12345',
  *     androidPackageName:'com.somecompany.app',
- *     androidURL:'example/home/cupertino/12345'
+ *     androidURL:'example/home/cupertino/12345',
+ *     data:{"walkScore":62, "transitScore":62}
  * }, function(err) { console.log(err); });
- * ```
  * ___
  */
 /*** +TOC_HEADING &Firebase App Indexing& ^ALL ***/
@@ -1798,23 +1799,30 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
 Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(done, options) {
 	var self = this;
 	options = options || {};
+
 	appindexing.updateAppIndexingTagsIfPresent();
 
-	if (!appindexing.state['iOSAppIndexingTagsPresent'] ||
-		!appindexing.state['androidAppIndexingTagsPresent']) {
+	appindexing.options = options;
 
-		appindexing.insertAppIndexingTagsFromConfig(options);
-
+	if (!appindexing.state['androidAppIndexingTagsPresent']) {
+		appindexing.insertAppIndexingTagsFromConfig('android');
 		if (!appindexing.state['androidDetailsComplete']) {
-			appindexing.populateConfigFromAppLinksTags('android', options);
-		}
-		if (!appindexing.state['iOSDetailsComplete']) {
-			appindexing.populateConfigFromAppLinksTags('iOS', options);
-		}
-		if (!appindexing.state['iOSDetailsComplete'] && !appindexing.state['androidDetailsComplete']) {
-			done('Firebase App Indexing tags were not added to your webpage. Please check your configuration.');
+			appindexing.populateConfigFromAppLinksTags('android');
 		}
 	}
-	done(null);
+
+	if (!appindexing.state['iosAppIndexingTagsPresent']) {
+		appindexing.insertAppIndexingTagsFromConfig('ios');
+		if (!appindexing.state['iosDetailsComplete']) {
+			appindexing.populateConfigFromAppLinksTags('ios');
+		}
+	}
+
+	if (!appindexing.state['iosDetailsComplete'] && !appindexing.state['androidDetailsComplete']) {
+		done('Firebase App Indexing tags were not added to your webpage. Please check your configuration.');
+	}
+	else {
+		done(null);
+	}
 });
 

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1761,10 +1761,10 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * | Key | Value
  * | --- | ---
  * | "androidPackageName" | Android App's package name
- * | "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content the App
+ * | "androidURL" | A custom scheme for your Android App such as: `example/home/cupertino/12345` where `example` is the App's URI scheme and `home/cupertino/12345` routes to unique content in the App
  * | "iosAppStoreId" | iTunes App Store ID for your iOS App
  * | "iosURL" | A custom scheme for your iOS App such as: `example/home/cupertino/12345`
- * | "data" | Any additional deep link data that you would like to pass to your App.
+ * | "data" | Any additional deep link data that you would like to pass to your App
  *
  * Resultant Firebase App Indexing tags will have the following format:
  *```
@@ -1772,7 +1772,7 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params_and_additional_deep_link_data}"/>
  *```
  * Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
- * Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch will append Branch tracking params to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
+ * Alternatively, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then Branch tracking params will be appended to the end of these tags and ignore what is passed into `Branch.autoAppIndex()`.
  *
  * Analytics related to Google's attempts to index your App's content via this method can be found from Source Analytics in Dashboard where `channel` is `Firebase App Indexing` and `feature` is `Auto App Indexing`.
  *
@@ -1826,4 +1826,3 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
 		done(null);
 	}
 });
-

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1771,10 +1771,9 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * <link rel="alternate" href="ios-app://{iosAppStoreId}/{iosURL}?{branch_tracking_params}"/>
  *
  * Note: If optional parameters above are not specified, Branch will try to build Firebase App Indexing tags using your page's App Links tags.
- * Also, if optional parameters are specified but Firebase App Indexing tags already exist on your webpage then, Branch will ignore parameters above 
- * and append Branch tracking params to the end of existing tags.
+ * Also, if optional parameters are specified but Firebase App Indexing tags already exist then, Branch will ignore them and append Branch tracking params to the end of the existing tags.
  *
- * Analytics related to Google's attempts to index your App via this method can be found from Source Analytics in Dashboard where 'channel' is 'Firebase App Indexing' and 'feature' is 'Auto App Indexing' 
+ * Analytics related to Google's attempts to index your App via this method can be found from Source Analytics in Dashboard where 'channel' equals 'Firebase App Indexing' and 'feature' equals 'Auto App Indexing'.
  *
  * ##### Usage
  * ```js

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1753,7 +1753,7 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * @param {Object} data - _optional_ - Information on how to build your App Indexing tags for your webpage
  * @param {function(?Error)=} callback - _optional_ - Returns an error string if unsuccessful
  *
- * This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage. 
+ * This function generates and inserts Firebase App Indexing tags between the <head></head> section of your webpage.
  * Once inserted, these tags will help Google index and surface content from your App in Google Search.
  *
  * Listed below are optional parameters which can be used to build your page's App Indexing Tags:
@@ -1762,9 +1762,9 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * | --- | ---
  * | "androidPackageName" | Android App's package name
  * | "androidURL" | A custom scheme for your Android App such as: 'example/home/cupertino/12345' where 'example' is the App's URI scheme and 'home/cupertino/12345' routes to unique content the App
- * | "iosAppStoreId" | iTunes App Store ID for your iOS App 
+ * | "iosAppStoreId" | iTunes App Store ID for your iOS App
  * | "iosURL" | A custom scheme for your iOS App such as: 'example/home/cupertino/12345'
- * 
+ *
  * Resultant Firebase App Indexing tags will have the following format:
  *
  * <link rel="alternate" href="androidapp://{androidPackageName}/{androidURL}?{branch_tracking_params}"/>
@@ -1783,13 +1783,14 @@ Branch.prototype['closeBanner'] = wrap(0, function(done) {
  * );
  * ```
  * ##### Example
- * ```js 
- * branch.autoAppIndex({ 
+ * ```js
+ * branch.autoAppIndex({
  *     iosAppId:'123456789',
  *     iosURL:'example/home/cupertino/12345',
  *     androidPackageName:'com.somecompany.app',
  *     androidURL:'example/home/cupertino/12345'
  * }, function(err) { console.log(err); });
+ * ```
  * ___
  */
 /*** +TOC_HEADING &Firebase App Indexing& ^ALL ***/
@@ -1799,12 +1800,12 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
 	options = options || {};
 	appindexing.updateAppIndexingTagsIfPresent();
 
-	if (!appindexing.state['iOSAppIndexingTagsPresent'] || 
+	if (!appindexing.state['iOSAppIndexingTagsPresent'] ||
 		!appindexing.state['androidAppIndexingTagsPresent']) {
 
 		appindexing.insertAppIndexingTagsFromConfig(options);
 
-		if (!appindexing.state['androidDetailsComplete']) { 
+		if (!appindexing.state['androidDetailsComplete']) {
 			appindexing.populateConfigFromAppLinksTags('android', options);
 		}
 		if (!appindexing.state['iOSDetailsComplete']) {

--- a/src/appindexing.js
+++ b/src/appindexing.js
@@ -36,7 +36,7 @@ appindexing.checkOptions = function(options) {
 		appindexing.state['androidDetailsComplete'] = true;
 		appindexing.addAppIndexingTag('android', options);
 	}
-	if (options.hasOwnProperty('iosAppId') && options.hasOwnProperty('iosUrl') && typeof options['iosAppId']!==undefined && typeof options['iosUrl']!==undefined){
+	if (options.hasOwnProperty('iosAppId') && options.hasOwnProperty('iosURL') && typeof options['iosAppId']!==undefined && typeof options['iosURL']!==undefined){
 		appindexing.state['iOSDetailsComplete'] = true;
 		appindexing.addAppIndexingTag('iOS', options);
 	}
@@ -50,7 +50,7 @@ appindexing.checkAppLinks = function(type, options) {
 			options['iosAppId'] = metaTags[counter].getAttribute('content');
 		}
 		if (type=='iOS' && metaTags[counter].getAttribute('property') === 'al:ios:url') {
-			options['iosUrl'] = metaTags[counter].getAttribute('content').replace('://','/');
+			options['iosURL'] = metaTags[counter].getAttribute('content').replace('://','/');
 		}
 		if (type=='android' && metaTags[counter].getAttribute('property') === 'al:android:package') {
 			options['androidPackageName'] = metaTags[counter].getAttribute('content');
@@ -78,7 +78,7 @@ appindexing.addAppIndexingTag = function(type, options) {
 		appindexing.state['addedAndroidTagDom'] = true;
 	} 
 	if (type == 'iOS' && appindexing.state['iOSDetailsComplete'] === true && appindexing.state['addediOSTagDom'] === false) {
-		href = 'ios-app://' + options['iosAppId'] + '/' + options['iosUrl'];
+		href = 'ios-app://' + options['iosAppId'] + '/' + options['iosURL'];
 		href = appindexing.addBranchTrackingParams(href);
 		appindexing.writeToDOM(href);
 		appindexing.state['addediOSTagDom'] = true;

--- a/src/appindexing.js
+++ b/src/appindexing.js
@@ -33,12 +33,13 @@ function addAppIndexingTag(type) {
 function addBranchTrackingParams(href) {
 
 	var branchTrackingParams = { "channel": "Firebase App Indexing", "feature": "Auto App Indexing", "$canonical_url": utils.getWindowLocation() }
-	if (typeof appindexing.options["data"] === "object"){
-		for (var key in appindexing.options["data"]) {
-			if (appindexing.options["data"].hasOwnProperty(key) && 
+	
+	if (typeof appindexing.options['data'] === 'object') {
+		for (var key in appindexing.options['data']) {
+			if (appindexing.options['data'].hasOwnProperty(key) && 
 				!branchTrackingParams.hasOwnProperty(key)) {
 
-				branchTrackingParams[key] = appindexing.options["data"][key];
+				branchTrackingParams[key] = appindexing.options['data'][key];
 			}
 		}
 	}

--- a/src/appindexing.js
+++ b/src/appindexing.js
@@ -32,7 +32,7 @@ function addAppIndexingTag(type) {
 /** Updates the 'href' attribute of a 'link' element to include Branch Tracking params. */
 function addBranchTrackingParams(href) {
 
-	var branchTrackingParams = { "channel": "Firebase App Indexing", "feature": "Auto App Indexing", "$canonical_url": utils.getWindowLocation() }
+	var branchTrackingParams = { "~channel": "Firebase App Indexing", "~feature": "Auto App Indexing", "$canonical_url": utils.getWindowLocation() }
 	
 	if (typeof appindexing.options['data'] === 'object') {
 		for (var key in appindexing.options['data']) {

--- a/src/appindexing.js
+++ b/src/appindexing.js
@@ -1,0 +1,93 @@
+'use strict';
+goog.provide('appindexing');
+
+goog.require('goog.json');// jshint unused:false
+goog.require('utils');
+
+
+appindexing.state = {};
+appindexing.state['androidAppIndexingTagsPresent'] = false;
+appindexing.state['iOSAppIndexingTagsPresent'] = false;
+appindexing.state['androidDetailsComplete'] = false;
+appindexing.state['iOSDetailsComplete'] = false;
+appindexing.state['addediOSTagDom'] = false;
+appindexing.state['addedAndroidTagDom'] = false;
+
+appindexing.checkForAppIndexingTags = function() {
+	var linkTags = document.getElementsByTagName('link');
+	var numLinkTags = linkTags.length;
+
+	for (var counter = 0; counter < numLinkTags; counter++) {
+		var currLinkTag = linkTags[counter];
+		var currLinkTagHref = currLinkTag.href;
+		if (currLinkTagHref.includes('ios-app')) {
+			appindexing.state['iOSAppIndexingTagsPresent'] = true;
+			currLinkTag.setAttribute('href',  appindexing.addBranchTrackingParams(currLinkTagHref));
+		}
+		if (currLinkTagHref.includes('android-app')) {
+			appindexing.state['androidAppIndexingTagsPresent'] = true;
+			currLinkTag.setAttribute('href',  appindexing.addBranchTrackingParams(currLinkTagHref));
+		}
+	}
+};
+
+appindexing.checkOptions = function(options) {
+	if (options.hasOwnProperty('androidPackageName') && options.hasOwnProperty('androidURL') && typeof options['androidPackageName']!==undefined && typeof options['androidURL']!==undefined){
+		appindexing.state['androidDetailsComplete'] = true;
+		appindexing.addAppIndexingTag('android', options);
+	}
+	if (options.hasOwnProperty('iosAppId') && options.hasOwnProperty('iosUrl') && typeof options['iosAppId']!==undefined && typeof options['iosUrl']!==undefined){
+		appindexing.state['iOSDetailsComplete'] = true;
+		appindexing.addAppIndexingTag('iOS', options);
+	}
+};
+
+appindexing.checkAppLinks = function(type, options) {
+	var metaTags = document.getElementsByTagName('meta');
+
+	for (var counter = 0; counter < metaTags.length; counter++) {
+		if (type=='iOS' && metaTags[counter].getAttribute('property') === 'al:ios:app_store_id') {
+			options['iosAppId'] = metaTags[counter].getAttribute('content');
+		}
+		if (type=='iOS' && metaTags[counter].getAttribute('property') === 'al:ios:url') {
+			options['iosUrl'] = metaTags[counter].getAttribute('content').replace('://','/');
+		}
+		if (type=='android' && metaTags[counter].getAttribute('property') === 'al:android:package') {
+			options['androidPackageName'] = metaTags[counter].getAttribute('content');
+		}
+		if (type=='android' && metaTags[counter].getAttribute('property') === 'al:android:url') {
+			options['androidURL'] = metaTags[counter].getAttribute('content').replace('://','/');
+		}
+	}
+	appindexing.checkOptions(options);
+};
+
+appindexing.addBranchTrackingParams = function(href) {
+	var branchTrackingParams = { "channel":"Firebase-App-Indexing", "$canonical_url":utils.getWindowLocation() }
+	var appendQueryStringUsing = '?';
+	if (href.indexOf('?') > -1) { appendQueryStringUsing = '&' };
+	return href + appendQueryStringUsing + 'link_click_id=a-' + btoa(JSON.stringify(branchTrackingParams));
+};
+
+appindexing.addAppIndexingTag = function(type, options) {
+	var href;
+	if (type === 'android' && appindexing.state['androidDetailsComplete'] === true && appindexing.state['addedAndroidTagDom'] === false) {
+		href = 'android-app://' + options['androidPackageName'] + '/' + options['androidURL'];
+		href = 	appindexing.addBranchTrackingParams(href);
+		appindexing.writeToDOM(href);
+		appindexing.state['addedAndroidTagDom'] = true;
+	} 
+	if (type == 'iOS' && appindexing.state['iOSDetailsComplete'] === true && appindexing.state['addediOSTagDom'] === false) {
+		href = 'ios-app://' + options['iosAppId'] + '/' + options['iosUrl'];
+		href = appindexing.addBranchTrackingParams(href);
+		appindexing.writeToDOM(href);
+		appindexing.state['addediOSTagDom'] = true;
+	}
+};
+
+appindexing.writeToDOM = function(href) {
+	var linkNode = document.createElement('link');
+	linkNode.setAttribute('rel', 'alternate');
+	linkNode.setAttribute('href', href);
+	document.head.appendChild(linkNode);
+};

--- a/src/appindexing.js
+++ b/src/appindexing.js
@@ -1,7 +1,7 @@
 'use strict';
 goog.provide('appindexing');
 
-goog.require('goog.json');// jshint unused:false
+goog.require('goog.json');
 goog.require('utils');
 
 
@@ -13,13 +13,23 @@ appindexing.state['iOSDetailsComplete'] = false;
 appindexing.state['addediOSTagDom'] = false;
 appindexing.state['addedAndroidTagDom'] = false;
 
-appindexing.checkForAppIndexingTags = function() {
+/** Scans through all 'link' tags then updates their 'href' values for those that contain 
+ * "ios-app" or "android-app" to include Branch tracking parameters.
+ * (Stage 1) 
+ */
+appindexing.updateAppIndexingTagsIfPresent = function() {
 	var linkTags = document.getElementsByTagName('link');
 	var numLinkTags = linkTags.length;
 
+	if (!numLinkTags) { return; }
+
 	for (var counter = 0; counter < numLinkTags; counter++) {
+
 		var currLinkTag = linkTags[counter];
 		var currLinkTagHref = currLinkTag.href;
+
+		if (!currLinkTagHref) { continue; }
+
 		if (currLinkTagHref.includes('ios-app')) {
 			appindexing.state['iOSAppIndexingTagsPresent'] = true;
 			currLinkTag.setAttribute('href',  appindexing.addBranchTrackingParams(currLinkTagHref));
@@ -31,18 +41,36 @@ appindexing.checkForAppIndexingTags = function() {
 	}
 };
 
-appindexing.checkOptions = function(options) {
-	if (options.hasOwnProperty('androidPackageName') && options.hasOwnProperty('androidURL') && typeof options['androidPackageName']!==undefined && typeof options['androidURL']!==undefined){
+/** Checks whether config contains appropriate per platform params. For Android, config needs to contain
+  * both androidPackageName and androidURL. For iOS both, iosAppId and iosURL. Once config is correctly set for
+  * iOS or Android, an App Indexing tag is built and inserted into the webpage.
+  * (Stage 2)
+  */
+appindexing.insertAppIndexingTagsFromConfig = function(options) {
+	if (options.hasOwnProperty('androidPackageName') &&
+		options.hasOwnProperty('androidURL') &&
+		typeof options['androidPackageName'] !== undefined &&
+		typeof options['androidURL'] !== undefined) {
+
 		appindexing.state['androidDetailsComplete'] = true;
 		appindexing.addAppIndexingTag('android', options);
 	}
-	if (options.hasOwnProperty('iosAppId') && options.hasOwnProperty('iosURL') && typeof options['iosAppId']!==undefined && typeof options['iosURL']!==undefined){
+	if (options.hasOwnProperty('iosAppId') && 
+		options.hasOwnProperty('iosURL') && 
+		typeof options['iosAppId'] !== undefined && 
+		typeof options['iosURL'] !== undefined) {
+
 		appindexing.state['iOSDetailsComplete'] = true;
 		appindexing.addAppIndexingTag('iOS', options);
 	}
 };
 
-appindexing.checkAppLinks = function(type, options) {
+/** If App Indexing tags do not exist and if the original config passed into autoAppIndex call does 
+  * not contain appropriate data, then as a last resort, this function will try to update the config from page's App Links tags.
+  * Once config is built it is validated and then if appropriate, App Indexing tags are built and inserted into the webpage.
+  * (Stage 3)
+ */
+appindexing.populateConfigFromAppLinksTags = function(type, options) {
 	var metaTags = document.getElementsByTagName('meta');
 
 	for (var counter = 0; counter < metaTags.length; counter++) {
@@ -59,25 +87,33 @@ appindexing.checkAppLinks = function(type, options) {
 			options['androidURL'] = metaTags[counter].getAttribute('content').replace('://','/');
 		}
 	}
-	appindexing.checkOptions(options);
+	appindexing.insertAppIndexingTagsFromConfig(options);
 };
 
+/** Updates the 'href' attribute of a 'link' element to include Branch Tracking params. */
 appindexing.addBranchTrackingParams = function(href) {
-	var branchTrackingParams = { "channel":"Firebase-App-Indexing", "$canonical_url":utils.getWindowLocation() }
-	var appendQueryStringUsing = '?';
-	if (href.indexOf('?') > -1) { appendQueryStringUsing = '&' };
-	return href + appendQueryStringUsing + 'link_click_id=a-' + btoa(JSON.stringify(branchTrackingParams));
+	var branchTrackingParams = { "channel": "Firebase App Indexing", "feature": "Auto App Indexing", "$canonical_url": utils.getWindowLocation() }
+	var appendQueryStringUsing = (href.indexOf('?') > -1) ? '&' : '?';
+
+	return href + appendQueryStringUsing + 'link_click_id=a-' + btoa(safejson.stringify(branchTrackingParams));
 };
 
+/** Builds the 'href' attribute of the 'link' element for insertion into the webpage **/
 appindexing.addAppIndexingTag = function(type, options) {
 	var href;
-	if (type === 'android' && appindexing.state['androidDetailsComplete'] === true && appindexing.state['addedAndroidTagDom'] === false) {
+	if (type === 'android' && 
+		appindexing.state['androidDetailsComplete'] && 
+		!appindexing.state['addedAndroidTagDom']) {
+
 		href = 'android-app://' + options['androidPackageName'] + '/' + options['androidURL'];
 		href = 	appindexing.addBranchTrackingParams(href);
 		appindexing.writeToDOM(href);
 		appindexing.state['addedAndroidTagDom'] = true;
 	} 
-	if (type == 'iOS' && appindexing.state['iOSDetailsComplete'] === true && appindexing.state['addediOSTagDom'] === false) {
+	if (type == 'iOS' && 
+		appindexing.state['iOSDetailsComplete'] && 
+		!appindexing.state['addediOSTagDom']) {
+
 		href = 'ios-app://' + options['iosAppId'] + '/' + options['iosURL'];
 		href = appindexing.addBranchTrackingParams(href);
 		appindexing.writeToDOM(href);
@@ -85,9 +121,10 @@ appindexing.addAppIndexingTag = function(type, options) {
 	}
 };
 
+/** Modifies the page's HTML to insert App Indexing tags between the <head></head> section of the webpage */
 appindexing.writeToDOM = function(href) {
-	var linkNode = document.createElement('link');
-	linkNode.setAttribute('rel', 'alternate');
-	linkNode.setAttribute('href', href);
-	document.head.appendChild(linkNode);
+	var linkElement = document.createElement('link');
+	linkElement.setAttribute('rel', 'alternate');
+	linkElement.setAttribute('href', href);
+	document.head.appendChild(linkElement);
 };

--- a/src/onpage.js
+++ b/src/onpage.js
@@ -35,6 +35,7 @@
 	[
 		'addListener',
 		'applyCode',
+		'autoAppIndex',
 		'banner',
 		'closeBanner',
 		'creditHistory',

--- a/test/branch-deps.js
+++ b/test/branch-deps.js
@@ -12,8 +12,9 @@ goog.addDependency("../../../../../src/3_banner_utils.js", ['banner_utils'], ['s
 goog.addDependency("../../../../../src/4_banner_css.js", ['banner_css'], ['banner_utils', 'utils']);
 goog.addDependency("../../../../../src/4_banner_html.js", ['banner_html'], ['banner_utils', 'utils', 'session', 'storage']);
 goog.addDependency("../../../../../src/5_banner.js", ['banner'], ['utils', 'banner_utils', 'banner_css', 'banner_html']);
-goog.addDependency("../../../../../src/6_branch.js", ['Branch'], ['goog.json', 'utils', 'resources', 'Server', 'banner', 'task_queue', 'storage', 'session', 'config', 'safejson', 'branch_view']);
+goog.addDependency("../../../../../src/6_branch.js", ['Branch'], ['goog.json', 'utils', 'resources', 'Server', 'banner', 'task_queue', 'storage', 'session', 'config', 'safejson', 'branch_view', 'appindexing']);
 goog.addDependency("../../../../../src/7_initialization.js", ['branch_instance'], ['Branch', 'config']);
+goog.addDependency("../../../../../src/appindexing.js", ['appindexing'], ['goog.json', 'utils']);
 goog.addDependency("../../../../../src/branch_view.js", ['branch_view'], ['utils', 'banner_css', 'safejson', 'journeys_utils']);
 goog.addDependency("../../../../../src/extern.js", [], []);
 goog.addDependency("../../../../../src/journeys_utils.js", ['journeys_utils'], ['banner_utils', 'safejson']);

--- a/test/branch-deps.js
+++ b/test/branch-deps.js
@@ -14,7 +14,7 @@ goog.addDependency("../../../../../src/4_banner_html.js", ['banner_html'], ['ban
 goog.addDependency("../../../../../src/5_banner.js", ['banner'], ['utils', 'banner_utils', 'banner_css', 'banner_html']);
 goog.addDependency("../../../../../src/6_branch.js", ['Branch'], ['goog.json', 'utils', 'resources', 'Server', 'banner', 'task_queue', 'storage', 'session', 'config', 'safejson', 'branch_view', 'appindexing']);
 goog.addDependency("../../../../../src/7_initialization.js", ['branch_instance'], ['Branch', 'config']);
-goog.addDependency("../../../../../src/appindexing.js", ['appindexing'], ['goog.json', 'utils']);
+goog.addDependency("../../../../../src/appindexing.js", ['appindexing'], ['safejson', 'utils']);
 goog.addDependency("../../../../../src/branch_view.js", ['branch_view'], ['utils', 'banner_css', 'safejson', 'journeys_utils']);
 goog.addDependency("../../../../../src/extern.js", [], []);
 goog.addDependency("../../../../../src/journeys_utils.js", ['journeys_utils'], ['banner_utils', 'safejson']);


### PR DESCRIPTION
This PR adds a function called **autoAppIndex()** which generates and inserts Firebase App Indexing tags between the <head></head> portion of the webpage calling it. 

For example, let's say that we call autoAppIndex() with:


```
 branch.autoAppIndex({
          iosAppId:'123456789',
          iosURL:'example/home/cupertino/12345',
	  androidPackageName:'com.somecompany.app',
	  androidURL:'example/home/cupertino/12345'
});
```

then the following App Indexing tags will be inserted into the <head></head> section of the webpage:

`<link rel="alternate" href="android-app://com.somecompany.app/example/home/cupertino/12345?link_click_id=a-eyJjaGFubmVsIjoiRmlyZWJhc2UtQXBwLUluZGV4aW5nIiwiJGNhbm9uaWNhbF91cmwiOiJmaWxlOi8vL1VzZXJzL3J1YmluL0Rlc2t0b3AvcmVwb3Mvd2ViLWJyYW5jaC1kZWVwLWxpbmtpbmcvZGlzdC8wMDQuaHRtbCJ9">`

`<link rel="alternate" href="ios-app://123456789/example/home/cupertino/12345?link_click_id=a-eyJjaGFubmVsIjoiRmlyZWJhc2UtQXBwLUluZGV4aW5nIiwiJGNhbm9uaWNhbF91cmwiOiJmaWxlOi8vL1VzZXJzL3J1YmluL0Rlc2t0b3AvcmVwb3Mvd2ViLWJyYW5jaC1kZWVwLWxpbmtpbmcvZGlzdC8wMDQuaHRtbCJ9">`

@yntema @jsaleigh 
