### PR TITLE
Remove goog.json.parse

### DIFF
--- a/src/0_jsonparse.js
+++ b/src/0_jsonparse.js
@@ -11,7 +11,7 @@ goog.require('goog.json');
 safejson.parse = function(sJSON) {
 	sJSON = String(sJSON);
 	try {
-		return (typeof JSON === 'object' && typeof JSON.parse === 'function') ? JSON.parse(sJSON) : goog.json.parse(sJSON);
+		return JSON.parse(sJSON);
 	}
 	catch (e) {
 


### PR DESCRIPTION
goog.json.parse uses eval() causing warnings. Getting rid of it since JSON.parse is very well supported.