### PR TITLE
WEBSDK-30 add creation source to link payload

### DIFF
--- a/src/2_resources.js
+++ b/src/2_resources.js
@@ -252,7 +252,8 @@ resources.link = {
 		"identity_id": validator(true, branch_id),
 		"stage": validator(false, validationTypes.STRING),
 		"tags": validator(false, validationTypes.ARRAY),
-		"type": validator(false, validationTypes.NUMBER)
+		"type": validator(false, validationTypes.NUMBER),
+		"source": validator(true, validationTypes.STRING)
 	})
 };
 
@@ -272,7 +273,8 @@ resources.deepview = {
 		"append_deeplink_path": validator(false, validationTypes.BOOLEAN),
 		"stage": validator(false, validationTypes.STRING),
 		"tags": validator(false, validationTypes.ARRAY),
-		"deepview_type": validator(true, validationTypes.STRING)
+		"deepview_type": validator(true, validationTypes.STRING),
+		"source": validator(true, validationTypes.STRING)		
 	})
 };
 

--- a/src/2_resources.js
+++ b/src/2_resources.js
@@ -253,7 +253,7 @@ resources.link = {
 		"stage": validator(false, validationTypes.STRING),
 		"tags": validator(false, validationTypes.ARRAY),
 		"type": validator(false, validationTypes.NUMBER),
-		"source": validator(true, validationTypes.STRING)
+		"source": validator(false, validationTypes.STRING)
 	})
 };
 


### PR DESCRIPTION
This adds `source` to the link payload that the web sdk sends to the API. This will help identify the link creation_source to be the Web SDK instead of just SDK.
 
@yntema 