### PR TITLE
JOUR-715 Remove default box shadow to support floating btn

### DIFF
--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -281,7 +281,7 @@ journeys_utils.addIframeOuterCSS = function() {
 			's ease; ' +
 			(bodyMargin) +
 			'; }\n' +
-		'#branch-banner-iframe { box-shadow: 0 0 5px rgba(0, 0, 0, .35); width: 1px; min-width:100%;' +
+		'#branch-banner-iframe { min-width:100%;' +
 			' left: 0; right: 0; border: 0; height: ' +
 			journeys_utils.bannerHeight +
 			'; z-index: 99999; -webkit-transition: all ' +


### PR DESCRIPTION
Journeys smart banners are rendered with a box-shadow by default. We want to remove this to support other types of banners, like a floating button.

Also removing the width of 1px because this doesn't do anything.