### PR TITLE
Remove box-shadow if no content background exists

### DIFF
--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -335,15 +335,18 @@ journeys_utils.addIframeInnerCSS = function(iframe, innerCSS) {
 	}
 
 	// remove box shadow if no content background color
+	// this is to allow floating button to work
 	try {
+		// get computed background-color of .branch-banner-content
 		var content = doc.getElementsByClassName('branch-banner-content')[0]
 		var contentComputedStyle = window.getComputedStyle(content)
 		var bg = contentComputedStyle.getPropertyValue('background-color')
 		var arr = bg.split(', ')
-		if (arr[3] && arr[3].charAt(0) === '0') {
+		// if the alpha === 0, remove the box shadow
+		if (arr[3] && parseInt(arr[3], 10)) {
 			iframe.style.boxShadow = "none";
 		}
-	} catch() {};
+	} catch(err) {};
 }
 
 /***

--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -271,6 +271,8 @@ journeys_utils.addIframeOuterCSS = function() {
 		})
 	}
 
+
+
 	iFrameCSS.innerHTML = 	
 		'body { -webkit-transition: all ' +
 			(banner_utils.animationSpeed * 1.5 / 1000) +
@@ -331,6 +333,17 @@ journeys_utils.addIframeInnerCSS = function(iframe, innerCSS) {
 	else if (journeys_utils.position === 'bottom') {
 		iframe.style.bottom = '-' + journeys_utils.bannerHeight;
 	}
+
+	// remove box shadow if no content background color
+	try {
+		var content = doc.getElementsByClassName('branch-banner-content')[0]
+		var contentComputedStyle = window.getComputedStyle(content)
+		var bg = contentComputedStyle.getPropertyValue('background-color')
+		var arr = bg.split(', ')
+		if (arr[3] && arr[3].charAt(0) === '0') {
+			iframe.style.boxShadow = "none";
+		}
+	} catch() {};
 }
 
 /***

--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -271,8 +271,6 @@ journeys_utils.addIframeOuterCSS = function() {
 		})
 	}
 
-
-
 	iFrameCSS.innerHTML = 	
 		'body { -webkit-transition: all ' +
 			(banner_utils.animationSpeed * 1.5 / 1000) +


### PR DESCRIPTION
Checks the computed background-color of the .branch-banner-content. If the alpha === 0, we can determine there is no background and thus remove the box-shadow. 

Allows for floating button banner.