### PR TITLE
INTENG-3122 - Allow init to complete when banner dismissed

### DIFF
--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -395,8 +395,12 @@ Branch.prototype['init'] = wrap(
 				if (!err && typeof eventData === 'object') {
 					self._branchViewEnabled = !!eventData['branch_view_enabled'];
 					self._storage.set('branch_view_enabled', self._branchViewEnabled);
-					var branchViewData = null;
-					var testFlag = null;
+
+					var branchViewData;
+					var testFlag;
+					var dismissTimeStamp;
+					var hideBanner;
+
 					if (branchViewId && utils.mobileUserAgent()) {
 						branchViewData = {
 							id: branchViewId,
@@ -407,17 +411,19 @@ Branch.prototype['init'] = wrap(
 					}
 					else if (eventData.hasOwnProperty('branch_view_data')) {
 						branchViewData = eventData['branch_view_data'];
-					}
-					if (branchViewData) {
-						var hideBanner = self._storage.get('hideBanner' + branchViewData["id"], true);
-						if (hideBanner && !testFlag) {
-							if (hideBanner === true || hideBanner > Date.now()) {
-								return;
-							}
-							else if (hideBanner < Date.now()) {
-								self._storage.remove('hideBanner' + branchViewData["id"], true);
-							}
+
+						// check storage to see dismiss timestamp
+						dismissTimeStamp = self._storage.get('hideBanner' + branchViewData["id"], true);
+
+						if (dismissTimeStamp < Date.now()) {
+							self._storage.remove('hideBanner' + branchViewData["id"], true);
 						}
+						else if (dismissTimeStamp === true || dismissTimeStamp > Date.now()) {
+							hideBanner = true;
+						}
+					}
+
+					if (branchViewData && !hideBanner) {
 						self['renderQueue'](function() {
 							var requestData = self._branchViewData || {};
 


### PR DESCRIPTION
Issue was that if the localStorage said banner should be hidden, the function would return instead of allowing it to finish initializing. 

Moved the dismiss banner logic up so that we could check if the banner should be shown and allow done() to be called if not.