### PR TITLE
JOUR-720 add support for no_journeys option in init

### DIFF
--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -286,9 +286,11 @@ Branch.prototype['init'] = wrap(
 		options = (options && typeof options === 'function') ? { } : options;
 
 		var branchViewId = null;
+		var no_journeys = null;
 
 		if (options) {
 			branchViewId = options.branch_view_id || null;
+			no_journeys = options.no_journeys || null;
 			self.user_language = options.user_language || utils.getBrowserLanguageCode();
 		}
 		if (!branchViewId) {
@@ -425,7 +427,7 @@ Branch.prototype['init'] = wrap(
 						}
 					}
 
-					if (branchViewData && !hideBanner) {
+					if (branchViewData && !hideBanner && !no_journeys) {
 						self['renderQueue'](function() {
 							var requestData = self._branchViewData || {};
 


### PR DESCRIPTION
Partners are asking for a way to be able to prevent a journey from showing using javascript. They will now be able to pass an option into init called no_journeys. If set to true, we will not show a journeys banner for that page.

JIRA: https://branch.atlassian.net/browse/JOUR-720