### PR TITLE
INTENG-3144 remove css from previous banner

### DIFF
--- a/src/branch_view.js
+++ b/src/branch_view.js
@@ -58,10 +58,18 @@ branch_view.handleBranchViewData = function(server, branchViewData, requestData,
 
 	var cleanedData = utils.cleanLinkData(requestData);
 
+	// if banner already exists, don't add another on
 	if (document.getElementById('branch-banner') ||
 		document.getElementById('branch-banner-iframe') ||
 		document.getElementById('branch-banner-container')) {
 		return;
+	}
+
+	// in some cases, css from a previous banner will remain.
+	// this code removes any leftover css
+	var branchCSS = document.getElementById('branch-iframe-css')
+	if (branchCSS) {
+		branchCSS.parentElement.removeChild(branchCSS)
 	}
 
 	var placeholder = document.createElement('div');

--- a/src/branch_view.js
+++ b/src/branch_view.js
@@ -65,8 +65,7 @@ branch_view.handleBranchViewData = function(server, branchViewData, requestData,
 		return;
 	}
 
-	// in some cases, css from a previous banner will remain.
-	// this code removes any leftover css
+	// this code removes any leftover css from previous banner
 	var branchCSS = document.getElementById('branch-iframe-css')
 	if (branchCSS) {
 		branchCSS.parentElement.removeChild(branchCSS)

--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -473,9 +473,16 @@ journeys_utils.animateBannerExit = function(banner) {
 		banner_utils.removeClass(document.body, 'branch-banner-is-active');
 	}, banner_utils.animationDelay);
 
+	// remove margin if the banner was injected
 	if (journeys_utils.divToInjectParents && journeys_utils.divToInjectParents.length > 0) {
 		journeys_utils.divToInjectParents.forEach(function(parent) {
 			parent.style.marginTop = 0;
 		})
+	}
+
+	// remove CSS that was added to the document body
+	var branchCSS = document.getElementById('branch-iframe-css')
+	if (branchCSS) {
+		branchCSS.parentElement.removeChild(branchCSS)
 	}
 }


### PR DESCRIPTION
A partner noticed that when clicking to a new page, a new banner would render, but some of the css was still on the page cause the content to get pushed down further than expected.

This code checks for the existence of #branch-banner-iframe style tag and removes it if it exists. Should not change any other functionality.