### PR TITLE
DANA-128 - add trackCommerceEvent() method

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -555,59 +555,47 @@ utils.getBrowserLanguageCode = function() {
 };
 
 /**
- * Returns the difference between two arrays. 
+ * Returns the difference between two arrays.
  */
 utils.calculateDiffBetweenArrays = function(original, toCheck) {
 	var diff = [];
 	toCheck.forEach(function(element) {
-		if(original.indexOf(element) == -1) {
+		if (original.indexOf(element) === -1) {
 			diff.push(element);
 		}
 	});
-
 	return diff;
-}
+};
 
-/** 
+/**
  * Validates the commerce-data object passed into branch.trackCommerceEvent().
  * If there are invalid keys present then it will report back what those keys are.
  * Note: The keys below are optional.
  */
 utils.validateCommerceData = function(commerceData) {
-	var allowedInRoot = ['common', 'type', 'transaction_id', 'currency', 'revenue', 'revenue_in_usd', 'exchange_rate', 'shipping', 'tax', 'coupon', 'affiliation', 'persona', 'products'];
-	var allowedInProducts = ['sku', 'name', 'price', 'quantity', 'brand', 'category', 'variant'];
+	var allowedInRoot = [ 'common', 'type', 'transaction_id', 'currency', 'revenue', 'revenue_in_usd', 'exchange_rate', 'shipping', 'tax', 'coupon', 'affiliation', 'persona', 'products' ];
+	var allowedInProducts = [ 'sku', 'name', 'price', 'quantity', 'brand', 'category', 'variant' ];
 
 	var invalidKeys = {
 		root: utils.calculateDiffBetweenArrays(allowedInRoot, Object.keys(commerceData)),
 		products: []
-	}
+	};
 
-	if(commerceData.hasOwnProperty('products')) {
+	if (commerceData.hasOwnProperty('products')) {
 		commerceData["products"].forEach(function(product) {
-			utils.merge(invalidKeys["products"], utils.calculateDiffBetweenArrays(allowedInProducts, Object.keys(product)));
+			invalidKeys['products'] = invalidKeys['products'].concat(utils.calculateDiffBetweenArrays(allowedInProducts, Object.keys(product)));
 		});
 	}
-
 	return invalidKeys;
-}
+};
 
-/** 
- * Builds an error message if partner provides invalid keys to commerce_data
- */
-utils.buildErrorMessageForCommerceData = function(invalidKeys) {
-	var errMessage = 'Please remove the following keys from ';
+utils.validCommerceEvents = [ 'purchase' ];
 
-	if (invalidKeys['root'].length) {
-		errMessage += 'the root of commerce_data: ' + invalidKeys['root'].join(', ');
-	}
+/** @type {Object<string,message>} */
+utils.commerceEventMessages = {
+	missingPurchaseEvent: 'event name is either missing, of the wrong type or not valid. Please specify \'purchase\' as the event name.',
+	missingCommerceData: 'commerce_data is either missing, of the wrong type or empty. Please ensure that commerce_data is constructed correctly.',
+	invalidKeysForRoot: 'Please remove the following keys from the root of commerce_data: ',
+	invalidKeysForProducts: 'Please remove the following keys from commerce_data.products: '
+};
 
-	if (invalidKeys['root'].length && invalidKeys['products'].length) {
-		errMessage += '. In addition, please remove the following keys from commerce_data.products: ' + invalidKeys['products'].join(', ') + '.';
-	}
-
-	else if (invalidKeys['products'].length) {
-		errMessage += 'commerce_data.products: ' + invalidKeys['products'].join(', ');
-	}
-
-	return errMessage;
-}

--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -553,3 +553,61 @@ utils.getBrowserLanguageCode = function() {
 	}
 	return code;
 };
+
+/**
+ * Returns the difference between two arrays. 
+ */
+utils.calculateDiffBetweenArrays = function(original, toCheck) {
+	var diff = [];
+	toCheck.forEach(function(element) {
+		if(original.indexOf(element) == -1) {
+			diff.push(element);
+		}
+	});
+
+	return diff;
+}
+
+/** 
+ * Validates the commerce-data object passed into branch.trackCommerceEvent().
+ * If there are invalid keys present then it will report back what those keys are.
+ * Note: The keys below are optional.
+ */
+utils.validateCommerceData = function(commerceData) {
+	var allowedInRoot = ['common', 'type', 'transaction_id', 'currency', 'revenue', 'revenue_in_usd', 'exchange_rate', 'shipping', 'tax', 'coupon', 'affiliation', 'persona', 'products'];
+	var allowedInProducts = ['sku', 'name', 'price', 'quantity', 'brand', 'category', 'variant'];
+
+	var invalidKeys = {
+		root: utils.calculateDiffBetweenArrays(allowedInRoot, Object.keys(commerceData)),
+		products: []
+	}
+
+	if(commerceData.hasOwnProperty('products')) {
+		commerceData["products"].forEach(function(product) {
+			utils.merge(invalidKeys["products"], utils.calculateDiffBetweenArrays(allowedInProducts, Object.keys(product)));
+		});
+	}
+
+	return invalidKeys;
+}
+
+/** 
+ * Builds an error message if partner provides invalid keys to commerce_data
+ */
+utils.buildErrorMessageForCommerceData = function(invalidKeys) {
+	var errMessage = 'Please remove the following keys from ';
+
+	if (invalidKeys['root'].length) {
+		errMessage += 'the root of commerce_data: ' + invalidKeys['root'].join(', ');
+	}
+
+	if (invalidKeys['root'].length && invalidKeys['products'].length) {
+		errMessage += '. In addition, please remove the following keys from commerce_data.products: ' + invalidKeys['products'].join(', ') + '.';
+	}
+
+	else if (invalidKeys['products'].length) {
+		errMessage += 'commerce_data.products: ' + invalidKeys['products'].join(', ');
+	}
+
+	return errMessage;
+}

--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -574,7 +574,9 @@ var commerceEventMessages = {
 	missingPurchaseEvent: 'event name is either missing, of the wrong type or not valid. Please specify \'purchase\' as the event name.',
 	missingCommerceData: 'commerce_data is either missing, of the wrong type or empty. Please ensure that commerce_data is constructed correctly.',
 	invalidKeysForRoot: 'Please remove the following keys from the root of commerce_data: ',
-	invalidKeysForProducts: 'Please remove the following keys from commerce_data.products: '
+	invalidKeysForProducts: 'Please remove the following keys from commerce_data.products: ',
+	invalidProductListType: 'commerce_data.products must be an array of objects',
+	invalidProductType: 'Each product in the products list must be an object'
 };
 
 /**
@@ -592,10 +594,23 @@ var validateCommerceDataKeys = function(commerceData) {
 	}
 
 	var invalidKeysForProducts = [];
+	var invalidProductType;
 	if (commerceData.hasOwnProperty('products')) {
+		// make sure products is an array
+		if (!Array.isArray(commerceData['products'])) {
+			return commerceEventMessages['invalidProductListType'];
+		}
 		commerceData['products'].forEach(function(product) {
+			// all product entries must be objects
+			if (typeof product !== 'object') {
+				invalidProductType = commerceEventMessages['invalidProductType'];
+			}
 			invalidKeysForProducts = invalidKeysForProducts.concat(utils.calculateDiffBetweenArrays(allowedInProducts, Object.keys(product)));
 		});
+
+		if (invalidProductType) {
+			return invalidProductType;
+		}
 
 		if (invalidKeysForProducts.length) {
 			return commerceEventMessages['invalidKeysForProducts'] + invalidKeysForProducts.join(', ');

--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -555,7 +555,8 @@ utils.getBrowserLanguageCode = function() {
 };
 
 /**
- * Returns the difference between two arrays.
+ * Returns an array which contains the difference in elements between the 'original' and 'toCheck' arrays.
+ * If there is no difference, an empty array will be returned.
  */
 utils.calculateDiffBetweenArrays = function(original, toCheck) {
 	var diff = [];
@@ -572,7 +573,7 @@ utils.calculateDiffBetweenArrays = function(original, toCheck) {
  * If there are invalid keys present then it will report back what those keys are.
  * Note: The keys below are optional.
  */
-utils.validateCommerceData = function(commerceData) {
+utils.validateCommerceDataKeys = function(commerceData) {
 	var allowedInRoot = [ 'common', 'type', 'transaction_id', 'currency', 'revenue', 'revenue_in_usd', 'exchange_rate', 'shipping', 'tax', 'coupon', 'affiliation', 'persona', 'products' ];
 	var allowedInProducts = [ 'sku', 'name', 'price', 'quantity', 'brand', 'category', 'variant' ];
 
@@ -582,11 +583,36 @@ utils.validateCommerceData = function(commerceData) {
 	};
 
 	if (commerceData.hasOwnProperty('products')) {
-		commerceData["products"].forEach(function(product) {
+		commerceData['products'].forEach(function(product) {
 			invalidKeys['products'] = invalidKeys['products'].concat(utils.calculateDiffBetweenArrays(allowedInProducts, Object.keys(product)));
 		});
 	}
 	return invalidKeys;
+};
+
+/**
+ * Returns an error message if the partner passes in an invalid event or commerce_data to branch.trackCommerceEvent()
+ */
+utils.validateCommerceEventParams = function(event, commerce_data) {
+	if (!event || typeof event !== 'string' || utils.validCommerceEvents.indexOf(event.toLowerCase()) === -1) {
+		return utils.commerceEventMessages.missingPurchaseEvent;
+	}
+
+	if (!commerce_data || typeof commerce_data !== 'object' || Object.keys(commerce_data).length === 0) {
+		return utils.commerceEventMessages.missingCommerceData;
+	}
+
+	var invalidKeys = utils.validateCommerceDataKeys(commerce_data);
+
+	if (invalidKeys['root'].length) {
+		return utils.commerceEventMessages.invalidKeysForRoot + invalidKeys['root'].join(', ');
+	}
+
+	else if (invalidKeys['products'].length) {
+		return utils.commerceEventMessages.invalidKeysForProducts + invalidKeys['products'].join(', ');
+	}
+
+	return null;
 };
 
 utils.validCommerceEvents = [ 'purchase' ];
@@ -598,4 +624,3 @@ utils.commerceEventMessages = {
 	invalidKeysForRoot: 'Please remove the following keys from the root of commerce_data: ',
 	invalidKeysForProducts: 'Please remove the following keys from commerce_data.products: '
 };
-

--- a/src/2_resources.js
+++ b/src/2_resources.js
@@ -297,3 +297,15 @@ resources.event = {
 		"initial_referrer": validator(false, validationTypes.STRING)
 	})
 };
+
+resources.commerceEvent = {
+	destination: config.api_endpoint,
+	endpoint: "/v1/event",
+	method: utils.httpMethod.POST,
+	params: defaults({
+		"event": validator(true, validationTypes.STRING),
+		"metadata": validator(false, validationTypes.OBJECT),
+		"initial_referrer": validator(false, validationTypes.STRING),
+		"commerce_data": validator(true, validationTypes.OBJECT)
+	})
+};

--- a/src/3_api.js
+++ b/src/3_api.js
@@ -153,7 +153,7 @@ Server.prototype.getUrl = function(resource, data) {
 
 	if (resource.endpoint === '/v1/event') {
 		d['metadata'] = safejson.stringify(d['metadata'] || {});
-		if (d.hasOwnProperty('commerce_data')){
+		if (d.hasOwnProperty('commerce_data')) {
 			d['commerce_data'] = safejson.stringify(d['commerce_data'] || {});
 		}
 	}
@@ -285,7 +285,7 @@ Server.prototype.XHRRequest = function(url, data, method, storage, callback, nop
 						data = {};
 					}
 				}
- 				callback(null, data, req.status);
+				callback(null, data, req.status);
 			}
 			else if (req.status === 402) {
 				callback(new Error('Not enough credits to redeem.'), null, req.status);

--- a/src/3_api.js
+++ b/src/3_api.js
@@ -153,6 +153,9 @@ Server.prototype.getUrl = function(resource, data) {
 
 	if (resource.endpoint === '/v1/event') {
 		d['metadata'] = safejson.stringify(d['metadata'] || {});
+		if (d.hasOwnProperty('commerce_data')){
+			d['commerce_data'] = safejson.stringify(d['commerce_data'] || {});
+		}
 	}
 
 	if (resource.endpoint === '/v1/open') {
@@ -282,7 +285,7 @@ Server.prototype.XHRRequest = function(url, data, method, storage, callback, nop
 						data = {};
 					}
 				}
-				callback(null, data, req.status);
+ 				callback(null, data, req.status);
 			}
 			else if (req.status === 402) {
 				callback(new Error('Not enough credits to redeem.'), null, req.status);

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1818,21 +1818,84 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
 	}
 });
 
-Branch.prototype['trackCommerceEvent'] = wrap(callback_params.CALLBACK_ERR, function(done, metadata, commerce_data) {
+/**
+ * @function Branch.trackCommerceEvent
+ * @param {String} event - _required_ - Name of the commerce event to be tracked. We currently 	support 'purchase' events.
+ * @param {Object} commerce_data - _required_ - Data that describes the commerce event.
+ * @param {Object} metadata - _optional_ - metadata you may want add to the event.
+ * @param {function(?Error)=} callback - _optional_
+ *
+ * Sends a user commerce event to the server.
+ *
+ * Use commerce events to track when a user purchases an item in your online store,
+ * makes an in-app purchase, or buys a subscription.  The commerce events are tracked in
+ * the Branch dashboard along with your other events so you can judge the effectiveness of
+ * campaigns and other analytics.
+ *
+ * ##### Usage
+ *
+ * ```js
+ * branch.trackCommerceEvent(
+ *     event,
+ *     commerce_data,
+ *     metadata,
+ *     callback (err)
+ * );
+ * ```
+ *
+ * ##### Example
+ *
+ * ```js
+ * var commerce_data = {
+ *     "revenue": 50.0,
+ *     "currency": "USD",
+ *     "transaction_id": "foo-transaction-id",
+ *     "shipping": 0.0,
+ *     "tax": 5.0,
+ *     "affiliation": "foo-affiliation",
+ *     "products": [
+ *          { "sku": "foo-sku-1", "name": "foo-item-1", "price": 45.00, "quantity": 1, "brand": "foo-brand",
+ *            "category": "Electronics", "variant": "foo-variant-1"},
+ *          { "sku": "foo-sku-2", "price": 2.50, "quantity": 2}
+ *      ],
+ * };
+ *
+ * var metadata =  { "foo": "bar" };
+ *
+ * branch.trackCommerceEvent('purchase', commerce_data, metadata, function(err) {
+ *     if(err){
+ *          console.log(err);
+ *     }
+ * });
+ * ```
+ */
+/*** +TOC_HEADING &Revenue Analytics& ^WEB ***/
+/*** +TOC_ITEM #trackcommerceevent &.trackCommerceEvent()& ^WEB ***/
+Branch.prototype['trackCommerceEvent'] = wrap(callback_params.CALLBACK_ERR, function(done, event, commerce_data, metadata) {
 	var self = this;
 
 	metadata = metadata || {};
 
-	commerce_data = commerce_data || {};
+	if (!event || typeof event !== 'string' || utils.validCommerceEvents.indexOf(event.toLowerCase()) === -1) {
+		return done(utils.commerceEventMessages.missingPurchaseEvent);
+	}
+
+	if (!commerce_data || typeof commerce_data !== 'object' || Object.keys(commerce_data).length === 0) {
+		return done(utils.commerceEventMessages.missingCommerceData);
+	}
 
 	var invalidKeys = utils.validateCommerceData(commerce_data);
 
-	if (invalidKeys["root"].length || invalidKeys["products"].length) {
-		done(utils.buildErrorMessageForCommerceData(invalidKeys));
+	if (invalidKeys["root"].length) {
+		return done(utils.commerceEventMessages.invalidKeysForRoot + invalidKeys['root'].join(', '));
+	}
+
+	else if (invalidKeys["products"].length) {
+		return done(utils.commerceEventMessages.invalidKeysForProducts + invalidKeys['products'].join(', '));
 	}
 
 	self._api(resources.commerceEvent, {
-		"event": 'purchase',
+		"event": event,
 		"metadata":utils.merge({
 			"url": document.URL,
 			"user_agent": navigator.userAgent,
@@ -1840,7 +1903,7 @@ Branch.prototype['trackCommerceEvent'] = wrap(callback_params.CALLBACK_ERR, func
 		}, metadata),
 		"initial_referrer": document.referrer,
 		"commerce_data": commerce_data
-	}, function(err, eventData) {
+	}, function(err, data) {
 		done(err || null);
 	});
 });

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1861,7 +1861,7 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
  * };
  *
  * var metadata =  { "foo": "bar" };
- *W
+ *
  * branch.trackCommerceEvent('purchase', commerce_data, metadata, function(err) {
  *     if(err) {
  *          throw err;

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1820,7 +1820,7 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
 
 /**
  * @function Branch.trackCommerceEvent
- * @param {String} event - _required_ - Name of the commerce event to be tracked. We currently 	support 'purchase' events.
+ * @param {String} event - _required_ - Name of the commerce event to be tracked. We currently support 'purchase' events.
  * @param {Object} commerce_data - _required_ - Data that describes the commerce event.
  * @param {Object} metadata - _optional_ - metadata you may want add to the event.
  * @param {function(?Error)=} callback - _optional_
@@ -1828,7 +1828,7 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
  * Sends a user commerce event to the server.
  *
  * Use commerce events to track when a user purchases an item in your online store,
- * makes an in-app purchase, or buys a subscription.  The commerce events are tracked in
+ * makes an in-app purchase, or buys a subscription. The commerce events are tracked in
  * the Branch dashboard along with your other events so you can judge the effectiveness of
  * campaigns and other analytics.
  *
@@ -1861,10 +1861,10 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
  * };
  *
  * var metadata =  { "foo": "bar" };
- *
+ *W
  * branch.trackCommerceEvent('purchase', commerce_data, metadata, function(err) {
- *     if(err){
- *          console.log(err);
+ *     if(err) {
+ *          throw err;
  *     }
  * });
  * ```
@@ -1873,37 +1873,27 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
 /*** +TOC_ITEM #trackcommerceevent &.trackCommerceEvent()& ^WEB ***/
 Branch.prototype['trackCommerceEvent'] = wrap(callback_params.CALLBACK_ERR, function(done, event, commerce_data, metadata) {
 	var self = this;
+	self['renderQueue'](function() {
 
-	metadata = metadata || {};
+		metadata = metadata || {};
 
-	if (!event || typeof event !== 'string' || utils.validCommerceEvents.indexOf(event.toLowerCase()) === -1) {
-		return done(utils.commerceEventMessages.missingPurchaseEvent);
-	}
+		var validationError = utils.validateCommerceEventParams(event, commerce_data);
+		if (validationError) {
+			return done(new Error(validationError));
+		}
 
-	if (!commerce_data || typeof commerce_data !== 'object' || Object.keys(commerce_data).length === 0) {
-		return done(utils.commerceEventMessages.missingCommerceData);
-	}
-
-	var invalidKeys = utils.validateCommerceData(commerce_data);
-
-	if (invalidKeys["root"].length) {
-		return done(utils.commerceEventMessages.invalidKeysForRoot + invalidKeys['root'].join(', '));
-	}
-
-	else if (invalidKeys["products"].length) {
-		return done(utils.commerceEventMessages.invalidKeysForProducts + invalidKeys['products'].join(', '));
-	}
-
-	self._api(resources.commerceEvent, {
-		"event": event,
-		"metadata":utils.merge({
-			"url": document.URL,
-			"user_agent": navigator.userAgent,
-			"language": navigator.language
-		}, metadata),
-		"initial_referrer": document.referrer,
-		"commerce_data": commerce_data
-	}, function(err, data) {
-		done(err || null);
+		self._api(resources.commerceEvent, {
+			"event": event,
+			"metadata": utils.merge({
+				"url": document.URL,
+				"user_agent": navigator.userAgent,
+				"language": navigator.language
+			}, metadata),
+			"initial_referrer": document.referrer,
+			"commerce_data": commerce_data
+		}, function(err, data) {
+			done(err || null);
+		});
 	});
+	done();
 });

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1841,10 +1841,6 @@ Branch.prototype['trackCommerceEvent'] = wrap(callback_params.CALLBACK_ERR, func
 		"initial_referrer": document.referrer,
 		"commerce_data": commerce_data
 	}, function(err, eventData) {
-		if (err){
-			done(err);
-		}
+		done(err || null);
 	});
-
-	done(null);
 });

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1817,3 +1817,34 @@ Branch.prototype['autoAppIndex'] = wrap(callback_params.CALLBACK_ERR, function(d
 		done(null);
 	}
 });
+
+Branch.prototype['trackCommerceEvent'] = wrap(callback_params.CALLBACK_ERR, function(done, metadata, commerce_data) {
+	var self = this;
+
+	metadata = metadata || {};
+
+	commerce_data = commerce_data || {};
+
+	var invalidKeys = utils.validateCommerceData(commerce_data);
+
+	if (invalidKeys["root"].length || invalidKeys["products"].length) {
+		done(utils.buildErrorMessageForCommerceData(invalidKeys));
+	}
+
+	self._api(resources.commerceEvent, {
+		"event": 'purchase',
+		"metadata":utils.merge({
+			"url": document.URL,
+			"user_agent": navigator.userAgent,
+			"language": navigator.language
+		}, metadata),
+		"initial_referrer": document.referrer,
+		"commerce_data": commerce_data
+	}, function(err, eventData) {
+		if (err){
+			done(err);
+		}
+	});
+
+	done(null);
+});

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1875,8 +1875,6 @@ Branch.prototype['trackCommerceEvent'] = wrap(callback_params.CALLBACK_ERR, func
 	var self = this;
 	self['renderQueue'](function() {
 
-		metadata = metadata || {};
-
 		var validationError = utils.validateCommerceEventParams(event, commerce_data);
 		if (validationError) {
 			return done(new Error(validationError));
@@ -1888,7 +1886,7 @@ Branch.prototype['trackCommerceEvent'] = wrap(callback_params.CALLBACK_ERR, func
 				"url": document.URL,
 				"user_agent": navigator.userAgent,
 				"language": navigator.language
-			}, metadata),
+			}, metadata || {}),
 			"initial_referrer": document.referrer,
 			"commerce_data": commerce_data
 		}, function(err, data) {

--- a/src/onpage.js
+++ b/src/onpage.js
@@ -56,7 +56,8 @@
 		'setBranchViewData',
 		'setIdentity',
 		'track',
-		'validateCode'
+		'validateCode',
+		'trackCommerceEvent'
 	],
 	0
 );


### PR DESCRIPTION
This PR adds the ability to send a purchase event from the WebSDK

Usage example:

```
var metadata =  { "foo": "bar" };

var commerce_data = {
    "revenue": 50.0,
    "currency": "USD",
    "transaction_id": "foo-transaction-id",
    "shipping": 0.0,
    "tax": 5.0,
    "affiliation": "foo",
    "products": [
        { "sku": "foo-sku-1", "name": "foo-item-1", "price": 45.00, "quantity": 1, "brand": "foo-brand",
            "category": "Electronics", 
            "variant": "foo-variant-1"
        }
        ,
        { "sku": "foo-sku-2", "price": 2.50, "quantity": 2}
    ],
};

branch.trackCommerceEvent('purchase', commerce_data, metadata, function(err){
    if(err){
        throw err;
    }
});
```