### PR TITLE
Use fixed closure-library version for tests

### DIFF
--- a/test/integration-test.html
+++ b/test/integration-test.html
@@ -8,7 +8,7 @@
 	<div id="mocha"></div>
 	<link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css" />
 	<link rel="stylesheet" type="text/css" href="mocha.css" />
-	<script src="../compiler/library/closure-library-master/closure/goog/base.js"></script>
+	<script src="../compiler/library/closure-library-20170218/closure/goog/base.js"></script>
 	<script>
 		goog.addDependency("../../../../../test/web-config.js", ['config'], []);
 	</script>

--- a/test/test.html
+++ b/test/test.html
@@ -14,7 +14,7 @@
 	<div id="mocha"></div>
 	<link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css" />
 	<link rel="stylesheet" type="text/css" href="mocha.css" />
-	<script src="../compiler/library/closure-library-master/closure/goog/base.js"></script>
+	<script src="../compiler/library/closure-library-20170218/closure/goog/base.js"></script>
 	<script src="branch-deps.js"></script>
 	<script src="../node_modules/mocha/mocha.js"></script>
 	<script src="../node_modules/sinon/pkg/sinon-1.17.3.js"></script>


### PR DESCRIPTION
Update closure-library path to reflect the version number. We are no longer using current master version in an attempt to stabilize releases.