### PR TITLE
WEBSDK-40 - Exit whiteListJourneysLanguageData if data is null or undefined

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -127,6 +127,10 @@ utils.whiteListJourneysLanguageData = function(sessionData) {
 	var data = sessionData['data'];
 	var retData = {};
 
+	if (!data) {
+		return {};
+	}
+
 	switch (typeof data) {
 		case 'string':
 			try {


### PR DESCRIPTION
We were seeing errors on a partners site. When data is null, we were trying to execute Object.keys on it. This change exits early if data is null or undefined.