### PR TITLE
Support `link_identifier` in branch.init() options

### DIFF
--- a/example.html
+++ b/example.html
@@ -51,6 +51,10 @@
 				<h4>Session and Identity</h4>
 				<div class="group">
 					<button id="init" class="btn btn-success">.init()</button>
+					<button id="init-options" class="btn btn-success">.init(key, { link_identifier }, callback)</button>
+					<input class="example-input" type="text" id="link_identifier" class="form-control" placeholder="link_identifier">
+				</div>
+				<div class="group">
 					<button id="data" class="btn btn-info">.data()</button>
 					<input class="example-input" type="text" id="identityID" class="form-control" placeholder="test@test.com">
 					<button id="setIdentity" class="btn btn-info">.setIdentity()</button>
@@ -125,6 +129,10 @@
 		var info = $('.info');
 		var request = $('.request');
 		var response = $('.response');
+		var desktop_url = window.location.href;
+		if (desktop_url.indexOf('?') > - 1) {
+			desktop_url = desktop_url.substring(0, window.location.href.indexOf('?'));
+		}
 		var sampleParams = {
 			tags: [ 'tag1', 'tag2' ],
 			channel: 'sample app',
@@ -133,7 +141,7 @@
 			type: 1,
 			data: {
 				mydata: 'bar',
-				'$desktop_url': 'https://cdn.branch.io/example.html',
+				'$desktop_url': desktop_url || 'https://cdn.branch.io/example.html',
 				'$og_title': 'Branch Metrics',
 				'$og_description': 'Branch Metrics',
 				'$og_image_url': 'http://branch.io/img/logo_icon_white.png'
@@ -154,6 +162,14 @@
 			request.html('branch.init();');
 			// Note that this example is using the key in two places, here and above
 			branch.init('key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv', function(err, data) {
+				response.html(err || JSON.stringify(data));
+			});
+		});
+		$('#init-options').click(function() {
+			request.html('branch.init(key, { link_identifier: \'link_identifier\' }, callback);');
+			var link_identifier = getInputVal('#link_identifier');;
+			// Note that this example is using the key in two places, here and above
+			branch.init('key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv', { link_identifier: link_identifier }, function(err, data) {
 				response.html(err || JSON.stringify(data));
 			});
 		});

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -223,7 +223,7 @@ Branch.prototype._publishEvent = function(event, data) {
 /**
  * @function Branch.init
  * @param {string} branch_key - _required_ - Your Branch [live key](http://dashboard.branch.io/settings), or (deprecated) your app id.
- * @param {Object=} options - _optional_ - { }.
+ * @param {Object=} options - _optional_ - options: link_identifier, pass down a _branch_match_id instead of using window.location.
  * @param {function(?Error, utils.sessionData=)=} callback - _optional_ - callback to read the
  * session data.
  *
@@ -316,7 +316,7 @@ Branch.prototype['init'] = wrap(
 		var url = (options && typeof options.url !== 'undefined' && options.url !== null) ?
 			options.url :
 			null;
-		var link_identifier = (utils.getParamValue('_branch_match_id') || utils.hashValue('r'));
+		var link_identifier = ((options || {}).link_identifier || utils.getParamValue('_branch_match_id') || utils.hashValue('r'));
 		var freshInstall = !sessionData || !sessionData['identity_id'];
 		self._branchViewEnabled = !!self._storage.get('branch_view_enabled');
 		var checkHasApp = function(sessionData, cb) {

--- a/test/6_branch.js
+++ b/test/6_branch.js
@@ -327,6 +327,58 @@ describe('Branch', function() {
 			}
 		);
 
+		it(
+			'should store in session and call open with link_identifier from options',
+			function(done) {
+				if (testUtils.go('?')) {
+					var branch = initBranch(false);
+					var assert = testUtils.plan(3, done);
+
+					branch.init(branch_sample_key, { link_identifier: 67890 }, function(err, data) {
+						assert.strictEqual(
+							JSON.parse(localStorage.getItem('branch_session_first')).click_id,
+							'67890',
+							'get param match id stored in local storage'
+						);
+						assert.strictEqual(
+							utils.mobileUserAgent() ?
+								'67890' :
+								JSON.parse(sessionStorage.getItem('branch_session')).click_id,
+							'67890',
+							'get param match id saved in session storage'
+						);
+					});
+
+					requests[0].callback(null, browser_fingerprint_id);
+					requests[1].callback(
+						null,
+						{
+							session_id: "1234",
+							something: "else"
+						}
+					);
+					requests[2].callback(null, {});
+
+					assert.deepEqual(
+						requests[1].obj,
+						{
+							"branch_key": branch_sample_key,
+							"link_identifier": '67890',
+							"initial_referrer": requests[1].obj.initial_referrer,
+							"is_referrable": 1,
+							"browser_fingerprint_id": browser_fingerprint_id,
+							"sdk": "web" + config.version,
+							"options": undefined
+						},
+						'Request to open params correct'
+					);
+				}
+				else {
+					done();
+				}
+			}
+		);
+
 		it('should not call has_app if no session present', function(done) {
 			var branch = initBranch(false);
 			var assert = testUtils.plan(2, done);


### PR DESCRIPTION
Adds the ability to send `link_identifier` as`branch.init` part of the `options` object:
```jsx
  branch.init(branch_key, { link_identifier: _branch_match_id }, callback);
```

The reasoning behind it is we currently use `branch.io` on a react/redux app and need to clear the query params before calling init, i.e.
```jsx
  const { router: { location: { query, pathname } = { } } = { } } = this.props;
  const link_identifier = query._branch_match_id;
  this.props.router.replace({ pathname }); // clears query string, and hence window.location.search
  // later in the code / component life-cycle
  window.branch.init(BRANCH_IO_KEY, { link_identifier }, (err = {}, data) => { ... });
```