### PR TITLE
WEBSDK-116 - fixes event listener bug

### DIFF
--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1645,6 +1645,7 @@ Branch.prototype['redeem'] = wrap(callback_params.CALLBACK_ERR, function(done, a
 Branch.prototype['addListener'] = function(event, listener) {
 	if (typeof event === 'function' && listener === undefined) {
 		listener = event;
+		event = null;
 	}
 	if (listener) {
 		this._listeners.push({

--- a/test/6_branch.js
+++ b/test/6_branch.js
@@ -1433,7 +1433,7 @@ describe('Branch', function() {
 				1,
 				'one listener listening with no event specified'
 			);
-			assert.strictEqual(listenerFired, 1, 'observer fired once');
+			assert.strictEqual(listenerFired, 2, 'historically, observer fired twice');
 		});
 	});
 


### PR DESCRIPTION
The following scenario:

```
var listener = function(event, data) { console.log(event, data); }
branch.addListener(listener);
```

was not working correctly before