### PR TITLE
JOUR-2408 - Make navigationTimingAPIEnabled a boolean

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -23,9 +23,7 @@ utils.nonce = ''; // Nonce value to allow for CSP whitelisting
 
 // Properties and function related to calculating Branch request roundtrip time
 utils.instrumentation = {};
-utils.navigationTimingAPIEnabled = function() {
-	return !!(window.performance && window.performance.timing && window.performance.timing.navigationStart);
-};
+utils.navigationTimingAPIEnabled = typeof window !== 'undefined' && !!(window.performance && window.performance.timing && window.performance.timing.navigationStart);
 utils.timeSinceNavigationStart = function() {
 	// in milliseconds
 	return (Date.now() - window.performance.timing.navigationStart).toString();


### PR DESCRIPTION
Currently branch-sdk throws `TypeError: undefined is not an object (evaluating 'window.performance.timing')` under Safari 8 due to navigationTimingAPIEnabled being declared as a Function but used as a Boolean. Implicitly casting function `utils.navigationTimingAPIEnabled` through if's condition expression always evaluates to true instead of running the feature detection inside the function.
https://github.com/BranchMetrics/web-branch-deep-linking/blob/d24cb1a37b5ff7840f565adb1e4c9c00a5ac77c1/src/6_branch.js#L297

I suggest making navigationTimingAPIEnabled a Boolean instead of a function to skip redundant function calls. And the `typeof window !== 'undefined'` check is added to prevent failing to initialize the module during server-side requires.
