### PR TITLE
Fix build - jessie sources deprecated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,14 @@ jobs:
            jshint -v || sudo npm install -g jshint ;
            which grunt 2>&1 >/dev/null || sudo npm install -g grunt-cli ;
     # Installing Java
-    - run: sudo su -c 'echo "deb http://deb.debian.org/debian jessie-backports main" >> /etc/apt/sources.list'
+    - run: sudo su -c 'echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list.d/jessie-backports.list'
+    - run: sudo sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
     - run: |
           sudo rm -rf /var/lib/apt/lists/*
-          sudo apt-get update
+          sudo apt-get -o Acquire::Check-Valid-Until=false update
           sudo apt install -t jessie-backports openjdk-8-jre-headless ca-certificates-java
     # Install aws cli
-    - run: sudo apt-get update && sudo apt-get install -qq -y python-pip libpython-dev ;
+    - run: sudo apt-get install -qq -y python-pip libpython-dev ;
            curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py ;
            pip install awscli --upgrade --user && echo 'export PATH=/home/circleci/.local/bin:$PATH' >> $BASH_ENV;
            sudo npm install -g slack-cli ;


### PR DESCRIPTION
@hubt @rubinsingh 

This repository needs to move to node10, this is otherwise just a patch fix on top of a really old version.