### PR TITLE
feat(core): expose getPerformanceMetrics() for per-phase Web SDK load timing [EMT-3753]

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -7,5 +7,5 @@
 
 module.exports = {
   require: ['./test/setup.js', './test/branch-deps.js', 'global-jsdom/register', './test/test-utils.js', './node_modules/sinon/lib/sinon.js'],
-  spec: ['./test/0_config.js','./test/0_queue.js','./test/1_utils.js','./test/6_branch_new.js', './test/journeys_utils.js']
+  spec: ['./test/0_config.js','./test/0_queue.js','./test/1_utils.js','./test/6_branch_new.js', './test/journeys_utils.js', './test/performance_metrics.js']
 };

--- a/README.md
+++ b/README.md
@@ -23,6 +23,44 @@ for full details.
 - [Troubleshooting]
 - [Web Full Reference]
 
+# Performance Monitoring
+
+`branch.getPerformanceMetrics()` returns sub-millisecond (`performance.now()`) timings for each phase of SDK initialization, so you can see exactly where load time goes. It is read-only, never throws, and sends nothing to Branch.
+
+Call it after `branch.init()` has finished (for example, from the init callback or later):
+
+```js
+branch.init('key_live_xxxxxxxxxxxx', function (err, data) {
+  console.log(branch.getPerformanceMetrics());
+});
+```
+
+It returns:
+
+```js
+{
+  performance_supported: true,        // false when the browser has no Performance API
+  timings: {                          // performance.now() timestamps in ms, or null if the phase did not occur
+    sdk_script_load_start, sdk_script_load_end, sdk_parse_end,
+    _r_request_start, _r_response_received,
+    v1_open_request_start, v1_open_response_received,
+    v1_pageview_request_start, v1_pageview_response_received,
+    banner_render_start, banner_render_end,
+    init_callback_fired
+  },
+  durations: {                        // computed differences in ms, or null if either bound is missing
+    sdk_script_download_ms, sdk_parse_ms,
+    _r_roundtrip_ms, v1_open_roundtrip_ms, v1_pageview_roundtrip_ms,
+    banner_render_ms,
+    total_init_ms                     // init_callback_fired - sdk_script_load_start
+  }
+}
+```
+
+A value is `null` when that phase did not happen: `_r_*` is null where `/_r` is skipped (for example Safari 11+), `banner_*` is null when no Journey is shown, and `sdk_script_load_*` is null when the SDK is bundled (npm import) instead of loaded from a `<script>` tag.
+
+`total_init_ms` ends at the `init()` callback (when deep link data is delivered), which completes after `/v1/open`. It does not include `/v1/pageview` or banner render, which run afterwards — use the raw `v1_pageview_response_received` / `banner_render_end` timestamps if you need the time to those later phases.
+
 # Running locally
 Download node 18 (if not using nix)
 

--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -67,7 +67,11 @@ utils.getScriptResourceTiming = function() {
 	var entries = window.performance.getEntriesByType('resource') || [];
 	for (var i = 0; i < entries.length; i++) {
 		var entryName = entries[i].name || '';
-		if (entryName.indexOf('branch') >= 0 && entryName.indexOf('.js') >= 0) {
+		var entryInitiator = entries[i].initiatorType || '';
+		// Match the Branch SDK script specifically: a script-initiated resource whose
+		// filename starts with "branch" and ends in .js -- not any URL that merely
+		// contains "branch" and ".js" (which could be a /branch/ path or an unrelated bundle).
+		if (entryInitiator === 'script' && /branch[^/]*\.js(\?.*)?$/.test(entryName)) {
 			var startTime = entries[i].startTime;
 			var responseEnd = entries[i].responseEnd;
 			return {

--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -42,6 +42,45 @@ utils.calculateBrtt = function(startTime) {
 	return (Date.now() - startTime).toString();
 };
 
+// High-precision performance timings exposed via branch.getPerformanceMetrics().
+// Kept separate from utils.instrumentation (brtt/Date.now, backend-bound) so that
+// the data sent to the backend stays untouched. Values are performance.now()
+// timestamps (fractional milliseconds).
+utils.performanceTimings = {};
+utils.performanceEnabled = typeof window !== 'undefined' &&
+	!!(window.performance && typeof window.performance.now === 'function');
+utils.markPerformance = function(name) {
+	// First write wins, so a re-init / disableTracking(false) re-init does not
+	// overwrite the original init measurement.
+	if (utils.performanceEnabled && !utils.performanceTimings.hasOwnProperty(name)) {
+		utils.performanceTimings[name] = window.performance.now();
+	}
+};
+utils.getScriptResourceTiming = function() {
+	// Returns { start, end } for the Branch SDK script from the Resource Timing
+	// API, or null when unavailable: no API, NPM bundle (no separate script
+	// resource), or cross-origin without a Timing-Allow-Origin header (responseEnd
+	// reads as 0 in that case, which we treat as null rather than a misleading 0).
+	if (!utils.performanceEnabled || typeof window.performance.getEntriesByType !== 'function') {
+		return null;
+	}
+	var entries = window.performance.getEntriesByType('resource') || [];
+	for (var i = 0; i < entries.length; i++) {
+		var entryName = entries[i].name || '';
+		if (entryName.indexOf('branch') >= 0 && entryName.indexOf('.js') >= 0) {
+			var startTime = entries[i].startTime;
+			var responseEnd = entries[i].responseEnd;
+			return {
+				// Explicit null checks (not `|| null`) so a legitimate startTime of 0
+				// is preserved, consistent with the duration null-safety below.
+				start: (startTime !== undefined && startTime !== null) ? startTime : null,
+				end: responseEnd ? responseEnd : null
+			};
+		}
+	}
+	return null;
+};
+
 utils.dismissEventToSourceMapping = {
 	'didClickJourneyClose': 'Button(X)',
 	'didClickJourneyContinue': 'Dismiss Journey text',

--- a/src/3_api.js
+++ b/src/3_api.js
@@ -18,6 +18,15 @@
 
  Server.prototype._jsonp_callback_index = 0;
 
+ // Maps the init-critical endpoints to the metric prefix used by
+ // branch.getPerformanceMetrics(). Endpoints not in this map are ignored by the
+ // high-precision performance collector.
+ var PERF_ENDPOINT_MAP = {
+	'/_r': '_r',
+	'/v1/open': 'v1_open',
+	'/v1/pageview': 'v1_pageview'
+ };
+
  /**
   * @param {Object} obj
   * @param {string} prefix
@@ -365,6 +374,11 @@
 
 	utils.currentRequestBrttTag = resource.endpoint + '-brtt';
 
+	var perfName = PERF_ENDPOINT_MAP[resource.endpoint];
+	if (perfName) {
+		utils.markPerformance(perfName + '_request_start');
+	}
+
 	if ((resource.endpoint === "/v1/url") && Object.keys(utils.instrumentation).length > 1) {
 		delete utils.instrumentation['-brtt'];
 		data['instrumentation'] = safejson.stringify(utils.merge({}, utils.instrumentation));
@@ -416,6 +430,12 @@
 	  * @type {function(?Error,*=): ?undefined}
 	*/
 	var done = function(err, data, status) {
+		// Mark the response only on a successful response; first write wins, so a
+		// retry-then-success records the first success and an errored/timed-out
+		// phase leaves its *_response_received unset (null roundtrip).
+		if (!err && perfName) {
+			utils.markPerformance(perfName + '_response_received');
+		}
 		if (typeof self.onAPIResponse === 'function') {
 			// Record every request and response, including retries
 			// Note status is always undefined for jsonp requests (/_r and

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -462,6 +462,11 @@ Branch.prototype['init'] = wrap(
 
 		var finishInit = function(err, data) {
 
+			// Marks the moment the SDK is about to hand session data to the
+			// developer's init() callback (covers both the error and success paths
+			// below). First write wins.
+			utils.markPerformance('init_callback_fired');
+
 			if (data) {
 				data = setBranchValues(data);
 
@@ -2030,5 +2035,61 @@ Branch.prototype['setAPIUrl'] = function(url) {
  */
 Branch.prototype['getAPIUrl'] = function() {
 	return config.api_endpoint;
+};
+
+/***
+ * @function Branch.getPerformanceMetrics
+ *
+ * Returns sub-millisecond timings (performance.now()) and computed durations for
+ * each SDK initialization phase: script load/parse, /_r, /v1/open, /v1/pageview,
+ * banner render, and the init() callback. Phases that did not occur return null
+ * (e.g. /_r skipped on Safari 11+, no banner rendered, or no Resource Timing /
+ * NPM bundle for script load). The returned object contains only numeric
+ * timestamps -- no URLs, identifiers, or PII -- and nothing is sent to Branch.
+ * The top-level "performance_supported" flag is false when the browser lacks the
+ * Performance API, which disambiguates "every timing is null because we could not
+ * measure" from "a phase was skipped". See the README "Performance Monitoring" section.
+ */
+Branch.prototype['getPerformanceMetrics'] = function() {
+	var marks = utils.performanceTimings || {};
+	var script = utils.getScriptResourceTiming();
+
+	var val = function(name) {
+		return marks.hasOwnProperty(name) ? marks[name] : null;
+	};
+	var dur = function(a, b) {
+		return (a !== null && a !== undefined && b !== null && b !== undefined) ? (b - a) : null;
+	};
+
+	var timings = {
+		'sdk_script_load_start': script ? script.start : null,
+		'sdk_script_load_end': script ? script.end : null,
+		'sdk_parse_end': val('sdk_parse_end'),
+		'_r_request_start': val('_r_request_start'),
+		'_r_response_received': val('_r_response_received'),
+		'v1_open_request_start': val('v1_open_request_start'),
+		'v1_open_response_received': val('v1_open_response_received'),
+		'v1_pageview_request_start': val('v1_pageview_request_start'),
+		'v1_pageview_response_received': val('v1_pageview_response_received'),
+		'banner_render_start': val('banner_render_start'),
+		'banner_render_end': val('banner_render_end'),
+		'init_callback_fired': val('init_callback_fired')
+	};
+
+	var durations = {
+		'sdk_script_download_ms': dur(timings['sdk_script_load_start'], timings['sdk_script_load_end']),
+		'sdk_parse_ms': dur(timings['sdk_script_load_end'], timings['sdk_parse_end']),
+		'_r_roundtrip_ms': dur(timings['_r_request_start'], timings['_r_response_received']),
+		'v1_open_roundtrip_ms': dur(timings['v1_open_request_start'], timings['v1_open_response_received']),
+		'v1_pageview_roundtrip_ms': dur(timings['v1_pageview_request_start'], timings['v1_pageview_response_received']),
+		'banner_render_ms': dur(timings['banner_render_start'], timings['banner_render_end']),
+		'total_init_ms': dur(timings['sdk_script_load_start'], timings['init_callback_fired'])
+	};
+
+	return {
+		'performance_supported': utils.performanceEnabled,
+		'timings': timings,
+		'durations': durations
+	};
 };
 

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -2083,6 +2083,8 @@ Branch.prototype['getPerformanceMetrics'] = function() {
 		'v1_open_roundtrip_ms': dur(timings['v1_open_request_start'], timings['v1_open_response_received']),
 		'v1_pageview_roundtrip_ms': dur(timings['v1_pageview_request_start'], timings['v1_pageview_response_received']),
 		'banner_render_ms': dur(timings['banner_render_start'], timings['banner_render_end']),
+		// Intentionally ends at the init() callback (per spec): excludes /v1/pageview and
+		// banner render, which complete afterwards. Use the raw timestamps for those.
 		'total_init_ms': dur(timings['sdk_script_load_start'], timings['init_callback_fired'])
 	};
 

--- a/src/7_initialization.js
+++ b/src/7_initialization.js
@@ -12,7 +12,8 @@ goog.require('utils'); // jshint unused:false
 
 // This file is the SDK entry point: it runs once the script has been downloaded
 // and parsed and the `branch` global is about to become available. Mark the parse
-// boundary here for branch.getPerformanceMetrics().
+// boundary here for branch.getPerformanceMetrics(). If performance.now() is not
+// available, the mark is silently skipped and performance_supported will be false.
 utils.markPerformance('sdk_parse_end');
 
 branch_instance = new Branch();

--- a/src/7_initialization.js
+++ b/src/7_initialization.js
@@ -8,6 +8,12 @@ goog.provide('branch_instance');
 
 goog.require('Branch');
 goog.require('config'); // jshint unused:false
+goog.require('utils'); // jshint unused:false
+
+// This file is the SDK entry point: it runs once the script has been downloaded
+// and parsed and the `branch` global is about to become available. Mark the parse
+// boundary here for branch.getPerformanceMetrics().
+utils.markPerformance('sdk_parse_end');
 
 branch_instance = new Branch();
 

--- a/src/branch_view.js
+++ b/src/branch_view.js
@@ -115,6 +115,9 @@ branch_view.displayJourney = function(html, requestData, templateId, branchViewD
     	return;
 	}
 
+	// Banner/Journey render begins here (past the exit-animation early return).
+	utils.markPerformance('banner_render_start');
+
 	journeys_utils.branchViewId = templateId;
 	journeys_utils.setJourneyLinkData(journeyLinkData);
 
@@ -172,7 +175,8 @@ branch_view.displayJourney = function(html, requestData, templateId, branchViewD
 			if (utils.navigationTimingAPIEnabled) {
 				utils.instrumentation['journey-load-time'] = utils.timeSinceNavigationStart();
 			}
-			
+			utils.markPerformance('banner_render_end');
+
 			document.body.removeChild(placeholder);
 		}
 		renderHtmlBlob(document.body, html, requestData['has_app_websdk'], finalHookupsOnIframeLoaded);

--- a/src/onpage.js
+++ b/src/onpage.js
@@ -59,7 +59,8 @@
 		'setRequestMetaData',
 		'setDMAParamsForEEA',
 		'setAPIUrl',
-		'getAPIUrl'
+		'getAPIUrl',
+		'getPerformanceMetrics'
 	],
 	0
 );

--- a/test/branch-deps.js
+++ b/test/branch-deps.js
@@ -11,7 +11,7 @@ goog.addDependency('../../../../src/4_banner_css.js', ['banner_css'], ['banner_u
 goog.addDependency('../../../../src/4_banner_html.js', ['banner_html'], ['banner_utils', 'session', 'storage', 'utils']);
 goog.addDependency('../../../../src/5_banner.js', ['banner'], ['banner_css', 'banner_html', 'banner_utils', 'utils']);
 goog.addDependency('../../../../src/6_branch.js', ['Branch'], ['Server', 'banner', 'branch_view', 'config', 'goog.json', 'journeys_utils', 'resources', 'safejson', 'session', 'storage', 'task_queue', 'utils'], {'lang': 'es6'});
-goog.addDependency('../../../../src/7_initialization.js', ['branch_instance'], ['Branch', 'config']);
+goog.addDependency('../../../../src/7_initialization.js', ['branch_instance'], ['Branch', 'config', 'utils']);
 goog.addDependency('../../../../src/branch_view.js', ['branch_view'], ['banner_css', 'journeys_utils', 'safejson', 'utils'], {'lang': 'es6'});
 goog.addDependency('../../../../src/extern.js', [], []);
 goog.addDependency('../../../../src/journeys_utils.js', ['journeys_utils'], ['banner_utils', 'safejson', 'utils'], {'lang': 'es6'});
@@ -28,6 +28,7 @@ goog.addDependency('../../../../test/blob-banner.js', [], []);
 goog.addDependency('../../../../test/blob-interstitial.js', [], []);
 goog.addDependency('../../../../test/journeys.js', [], ['Branch', 'banner_utils', 'branch_view', 'config', 'goog.json', 'resources', 'session', 'storage', 'utils'], {'lang': 'es5'});
 goog.addDependency('../../../../test/journeys_utils.js', [], ['journeys_utils'], {'lang': 'es6'});
+goog.addDependency('../../../../test/performance_metrics.js', [], ['Branch', 'utils']);
 goog.addDependency('../../../../test/saucelabs.js', [], []);
 goog.addDependency('../../../../test/setup.js', [], []);
 goog.addDependency('../../../../test/test-utils.js', [], [], {'lang': 'es5'});

--- a/test/performance_metrics.js
+++ b/test/performance_metrics.js
@@ -1,0 +1,111 @@
+'use strict';
+/*jshint esversion: 6 */
+goog.require('utils');
+goog.require('Branch');
+
+// Covers EMT-3753 Deliverable 1 — branch.getPerformanceMetrics().
+// These tests exercise the pure assembly/null-safety logic by seeding
+// utils.performanceTimings directly, so they do not need a full init round-trip.
+describe('getPerformanceMetrics', function() {
+	var assert = testUtils.unplanned();
+
+	var TIMING_KEYS = [
+		'sdk_script_load_start', 'sdk_script_load_end', 'sdk_parse_end',
+		'_r_request_start', '_r_response_received',
+		'v1_open_request_start', 'v1_open_response_received',
+		'v1_pageview_request_start', 'v1_pageview_response_received',
+		'banner_render_start', 'banner_render_end', 'init_callback_fired'
+	];
+	var DURATION_KEYS = [
+		'sdk_script_download_ms', 'sdk_parse_ms',
+		'_r_roundtrip_ms', 'v1_open_roundtrip_ms', 'v1_pageview_roundtrip_ms',
+		'banner_render_ms', 'total_init_ms'
+	];
+
+	beforeEach(function() {
+		// Reset the module-global collector between tests.
+		utils.performanceTimings = {};
+	});
+
+	// FR-001: contract shape
+	it('returns the { performance_supported, timings, durations } contract with every key present', function() {
+		var metrics = new Branch().getPerformanceMetrics();
+		assert.deepEqual(Object.keys(metrics).sort(), ['durations', 'performance_supported', 'timings'], 'top-level keys');
+		assert.strictEqual(typeof metrics.performance_supported, 'boolean', 'performance_supported is a boolean');
+		TIMING_KEYS.forEach(function(k) {
+			assert(metrics.timings.hasOwnProperty(k), 'timings.' + k + ' present');
+		});
+		DURATION_KEYS.forEach(function(k) {
+			assert(metrics.durations.hasOwnProperty(k), 'durations.' + k + ' present');
+		});
+	});
+
+	// FR-006: null-safety when nothing was marked
+	it('returns null for every timing and duration when no phase was marked', function() {
+		var metrics = new Branch().getPerformanceMetrics();
+		TIMING_KEYS.forEach(function(k) {
+			assert.strictEqual(metrics.timings[k], null, 'timings.' + k + ' is null');
+		});
+		DURATION_KEYS.forEach(function(k) {
+			assert.strictEqual(metrics.durations[k], null, 'durations.' + k + ' is null');
+		});
+	});
+
+	// FR-002 + contract math: durations computed as differences
+	it('computes durations from seeded timestamps', function() {
+		utils.performanceTimings = {
+			'sdk_parse_end': 250,
+			'_r_request_start': 300,
+			'_r_response_received': 1100,
+			'v1_open_request_start': 1110,
+			'v1_open_response_received': 1800,
+			'v1_pageview_request_start': 1810,
+			'v1_pageview_response_received': 2200,
+			'init_callback_fired': 1800
+		};
+		var d = new Branch().getPerformanceMetrics().durations;
+		assert.strictEqual(d._r_roundtrip_ms, 800, '_r roundtrip');
+		assert.strictEqual(d.v1_open_roundtrip_ms, 690, 'open roundtrip');
+		assert.strictEqual(d.v1_pageview_roundtrip_ms, 390, 'pageview roundtrip');
+	});
+
+	// FR-004: /_r skipped (Safari 11+) yields null _r timings, others populated
+	it('keeps _r timings null when /_r is skipped but reports the other phases', function() {
+		utils.performanceTimings = {
+			'v1_open_request_start': 100,
+			'v1_open_response_received': 700
+		};
+		var m = new Branch().getPerformanceMetrics();
+		assert.strictEqual(m.timings._r_request_start, null, '_r start null');
+		assert.strictEqual(m.timings._r_response_received, null, '_r received null');
+		assert.strictEqual(m.durations._r_roundtrip_ms, null, '_r roundtrip null');
+		assert.strictEqual(m.durations.v1_open_roundtrip_ms, 600, 'open roundtrip computed');
+	});
+
+	// FR-005: absent banner yields null banner timings
+	it('returns null banner timings when no banner was rendered', function() {
+		utils.performanceTimings = { 'init_callback_fired': 500 };
+		var m = new Branch().getPerformanceMetrics();
+		assert.strictEqual(m.timings.banner_render_start, null, 'banner start null');
+		assert.strictEqual(m.timings.banner_render_end, null, 'banner end null');
+		assert.strictEqual(m.durations.banner_render_ms, null, 'banner duration null');
+	});
+
+	// EDGE-07: markPerformance is first-write-wins
+	it('markPerformance records only the first value for a given name', function() {
+		utils.markPerformance('v1_open_request_start');
+		var first = utils.performanceTimings.v1_open_request_start;
+		utils.markPerformance('v1_open_request_start');
+		assert.strictEqual(utils.performanceTimings.v1_open_request_start, first, 'value not overwritten');
+		assert.strictEqual(typeof first, 'number', 'value is a numeric performance.now() timestamp');
+	});
+
+	// NFR-PERF-001: instrumentation overhead < 1ms for the full set of marks
+	it('marks all init phases in well under 1ms total', function() {
+		var names = TIMING_KEYS.slice();
+		var start = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+		names.forEach(function(n) { utils.markPerformance(n); });
+		var elapsed = ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - start;
+		assert(elapsed < 1, 'marking ' + names.length + ' phases took ' + elapsed.toFixed(4) + 'ms (< 1ms)');
+	});
+});

--- a/test/performance_metrics.js
+++ b/test/performance_metrics.js
@@ -1,7 +1,10 @@
 'use strict';
 /*jshint esversion: 6 */
+var sinon = require('sinon');
 goog.require('utils');
 goog.require('Branch');
+goog.require('branch_view');
+goog.require('journeys_utils');
 
 // Covers EMT-3753 Deliverable 1 — branch.getPerformanceMetrics().
 // These tests exercise the pure assembly/null-safety logic by seeding
@@ -136,6 +139,40 @@ describe('getPerformanceMetrics', function() {
 				{ name: 'https://cdn.branch.io/branch-latest.min.js', initiatorType: 'script', startTime: 12, responseEnd: 0 }
 			]);
 			assert.deepEqual(utils.getScriptResourceTiming(), { start: 12, end: null }, 'end null when responseEnd is 0');
+		});
+	});
+
+	describe('banner render timings', function() {
+		var fs = require('fs');
+		var path = require('path');
+		var bannerHtml = fs.readFileSync(path.join(__dirname, 'blob-banner.html'), 'utf8');
+		var sb;
+
+		beforeEach(function() {
+			utils.performanceTimings = {};
+			sb = sinon.createSandbox();
+			// Minimal SDK state the render path reads.
+			journeys_utils.branch = { _publishEvent: function() {}, _storage: { get: function() { return null; }, set: function() {} } };
+			// Isolate from the journey-rendering internals; this test only asserts the perf marks.
+			['finalHookups', 'addHtmlToIframe', 'addIframeOuterCSS', 'addIframeInnerCSS', 'addDynamicCtaText', 'animateBannerEntrance', 'getJsAndAddToParent'].forEach(function(fn) {
+				if (typeof journeys_utils[fn] === 'function') { sb.stub(journeys_utils, fn); }
+			});
+		});
+		afterEach(function() { sb.restore(); });
+
+		it('marks banner_render_start when displayJourney runs and banner_render_end when the iframe loads', function() {
+			var requestData = { has_app_websdk: false, callback_string: 'branch_view_callback__test' };
+			branch_view.displayJourney(bannerHtml, requestData, '345', { id: '345' }, false, { type: 'desktop', variant: 'default' });
+			assert(utils.performanceTimings.hasOwnProperty('banner_render_start'), 'banner_render_start marked when displayJourney runs');
+
+			var iframe = document.getElementById('branch-banner-iframe');
+			assert(iframe, 'banner iframe was created');
+			// Fire the load handler deterministically; null it first so jsdom's own async
+			// load event does not re-run the cleanup (which would throw NotFoundError).
+			var onload = iframe.onload;
+			iframe.onload = null;
+			if (typeof onload === 'function') { onload.call(iframe); }
+			assert(utils.performanceTimings.hasOwnProperty('banner_render_end'), 'banner_render_end marked after the iframe loads');
 		});
 	});
 });

--- a/test/performance_metrics.js
+++ b/test/performance_metrics.js
@@ -101,4 +101,41 @@ describe('getPerformanceMetrics', function() {
 		var elapsed = ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - start;
 		assert(elapsed < 1, 'marking ' + names.length + ' phases took ' + elapsed.toFixed(4) + 'ms (< 1ms)');
 	});
+
+	describe('getScriptResourceTiming', function() {
+		var original;
+		function stubEntries(entries) {
+			original = window.performance.getEntriesByType;
+			window.performance.getEntriesByType = function() { return entries; };
+		}
+		afterEach(function() {
+			if (original) { window.performance.getEntriesByType = original; original = null; }
+		});
+
+		it('matches the Branch SDK script (script initiator + branch*.js filename) and returns its timing', function() {
+			stubEntries([
+				{ name: 'https://analytics.example.com/analytics.js', initiatorType: 'script', startTime: 1, responseEnd: 2 },
+				{ name: 'https://cdn.branch.io/branch/loader.css', initiatorType: 'link', startTime: 3, responseEnd: 4 },
+				{ name: 'https://api2.branch.io/v1/open', initiatorType: 'xmlhttprequest', startTime: 5, responseEnd: 6 },
+				{ name: 'https://cdn.branch.io/branch-latest.min.js', initiatorType: 'script', startTime: 10, responseEnd: 25 }
+			]);
+			assert.deepEqual(utils.getScriptResourceTiming(), { start: 10, end: 25 }, 'returns the branch script start/end');
+		});
+
+		it('ignores a /branch/ directory segment and non-script resources (no false positive)', function() {
+			stubEntries([
+				{ name: 'https://cdn.branch.io/branch/loader.js', initiatorType: 'script', startTime: 3, responseEnd: 4 },
+				{ name: 'https://x/app.js', initiatorType: 'script', startTime: 1, responseEnd: 2 },
+				{ name: 'https://cdn.branch.io/branch-latest.min.js', initiatorType: 'xmlhttprequest', startTime: 7, responseEnd: 9 }
+			]);
+			assert.strictEqual(utils.getScriptResourceTiming(), null, 'no match -> null');
+		});
+
+		it('treats a cross-origin responseEnd of 0 as null (no misleading zero)', function() {
+			stubEntries([
+				{ name: 'https://cdn.branch.io/branch-latest.min.js', initiatorType: 'script', startTime: 12, responseEnd: 0 }
+			]);
+			assert.deepEqual(utils.getScriptResourceTiming(), { start: 12, end: null }, 'end null when responseEnd is 0');
+		});
+	});
 });

--- a/test/performance_metrics.js
+++ b/test/performance_metrics.js
@@ -27,7 +27,6 @@ describe('getPerformanceMetrics', function() {
 		utils.performanceTimings = {};
 	});
 
-	// FR-001: contract shape
 	it('returns the { performance_supported, timings, durations } contract with every key present', function() {
 		var metrics = new Branch().getPerformanceMetrics();
 		assert.deepEqual(Object.keys(metrics).sort(), ['durations', 'performance_supported', 'timings'], 'top-level keys');
@@ -40,7 +39,6 @@ describe('getPerformanceMetrics', function() {
 		});
 	});
 
-	// FR-006: null-safety when nothing was marked
 	it('returns null for every timing and duration when no phase was marked', function() {
 		var metrics = new Branch().getPerformanceMetrics();
 		TIMING_KEYS.forEach(function(k) {
@@ -51,7 +49,6 @@ describe('getPerformanceMetrics', function() {
 		});
 	});
 
-	// FR-002 + contract math: durations computed as differences
 	it('computes durations from seeded timestamps', function() {
 		utils.performanceTimings = {
 			'sdk_parse_end': 250,
@@ -69,7 +66,6 @@ describe('getPerformanceMetrics', function() {
 		assert.strictEqual(d.v1_pageview_roundtrip_ms, 390, 'pageview roundtrip');
 	});
 
-	// FR-004: /_r skipped (Safari 11+) yields null _r timings, others populated
 	it('keeps _r timings null when /_r is skipped but reports the other phases', function() {
 		utils.performanceTimings = {
 			'v1_open_request_start': 100,
@@ -82,7 +78,6 @@ describe('getPerformanceMetrics', function() {
 		assert.strictEqual(m.durations.v1_open_roundtrip_ms, 600, 'open roundtrip computed');
 	});
 
-	// FR-005: absent banner yields null banner timings
 	it('returns null banner timings when no banner was rendered', function() {
 		utils.performanceTimings = { 'init_callback_fired': 500 };
 		var m = new Branch().getPerformanceMetrics();
@@ -91,7 +86,6 @@ describe('getPerformanceMetrics', function() {
 		assert.strictEqual(m.durations.banner_render_ms, null, 'banner duration null');
 	});
 
-	// EDGE-07: markPerformance is first-write-wins
 	it('markPerformance records only the first value for a given name', function() {
 		utils.markPerformance('v1_open_request_start');
 		var first = utils.performanceTimings.v1_open_request_start;
@@ -100,7 +94,6 @@ describe('getPerformanceMetrics', function() {
 		assert.strictEqual(typeof first, 'number', 'value is a numeric performance.now() timestamp');
 	});
 
-	// NFR-PERF-001: instrumentation overhead < 1ms for the full set of marks
 	it('marks all init phases in well under 1ms total', function() {
 		var names = TIMING_KEYS.slice();
 		var start = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();


### PR DESCRIPTION
## Summary

Implements `branch.getPerformanceMetrics()` — a public Web SDK API returning sub-millisecond (`performance.now()`) timings for each phase of SDK initialization, so customers and support can attribute slow page loads to a specific request instead of guessing. This is Deliverable 1 of the EMT-3753 performance-research spike.

## Context

A customer reported the Web SDK consuming ~2,800ms of their onLoad budget via a sequential request waterfall (SDK script load → `/_r` → `/v1/open` → `/v1/pageview`). We had no in-SDK, customer-accessible way to get a per-phase breakdown in the customer's own environment. This API closes that gap.

## What's included

- **Collector** (`src/1_utils.js`): `utils.performanceTimings` + `markPerformance()` (first-write-wins) + `getScriptResourceTiming()`, kept separate from the existing `Date.now()`-based `brtt` instrumentation so backend-bound data is untouched.
- **Phase marks** captured centrally in the transport layer keyed by endpoint (`PERF_ENDPOINT_MAP`: `/_r`, `/v1/open`, `/v1/pageview`), plus `sdk_parse_end`, `banner_render_*`, and `init_callback_fired` (`src/3_api.js`, `src/7_initialization.js`, `src/branch_view.js`, `src/6_branch.js`).
- **Public method** `getPerformanceMetrics()` returning `{ performance_supported, timings, durations }`, registered in the embed snippet `funcs` array (`src/6_branch.js`, `src/onpage.js`).
- **Tests** (`test/performance_metrics.js`): contract shape, null-safety (`_r` skipped / no banner), duration math, first-write-wins, and < 1ms overhead.
- **README** "Performance Monitoring" section.

## Behavior notes

- A value is `null` when its phase did not occur: `_r_*` when `/_r` is skipped (e.g. Safari 11+), `banner_*` when no Journey is shown, `sdk_script_load_*` for npm-bundled integrations.
- `performance_supported` is `false` when the browser lacks the Performance API, disambiguating "could not measure" from "phase skipped".
- `total_init_ms` ends at the `init()` callback (after `/v1/open`); it does **not** include `/v1/pageview` or banner render — the raw timestamps for those are in the object.
- Read-only, never throws, sends nothing to Branch.

## Out of scope (follow-ups)

- The npm-import vs `<script>`-tag benchmark (originally Task 2) — needs its own bundler project; being split into a separate ticket.
- Reducing the latency itself (parallelizing/collapsing the `_r → open → pageview` waterfall) — an SDK design change, tracked separately.

## Verification

- Closure ADVANCED build: 0 errors; public symbol survives minification.
- Full suite green (162 passing) on Node 24.
- Overhead measured < 1ms.
- Validated in a real headless Chrome run against `api2.branch.io`: per-phase timings populate, and under network throttling the totals reproduce the reported waterfall pattern.
