### PR TITLE
[patch] ENGMT-1981: preserve BE-supplied body CSS through Journey exit animation

### DIFF
--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -340,6 +340,55 @@ journeys_utils.addHtmlToIframe = function(iframe, html, userAgent) {
 	}
 }
 
+function getBodyRuleFromIframeCss(cssIframeContainer) {
+	const tempStyle = document.createElement('style');
+	tempStyle.textContent = cssIframeContainer;
+	document.head.appendChild(tempStyle);
+
+	const cssRules = (tempStyle.sheet && tempStyle.sheet.cssRules) || [];
+	document.head.removeChild(tempStyle);
+
+	for (let i = 0; i < cssRules.length; i++) {
+		if (cssRules[i].selectorText === 'body') {
+			return cssRules[i];
+		}
+	}
+
+	return null;
+}
+
+/***
+ * @function applyBodyCssFromIframeContainer
+ * @param {string} cssIframeContainer - CSS text supplied by the BE for the iframe container
+ * @param {number} bodyMarginTopNumber - margin-top (in px) the body already had before this Journey
+ * @param {number} bodyMarginBottomNumber - margin-bottom (in px) the body already had before this Journey
+ *
+ * Parse the BE's CSS via a throwaway stylesheet
+ * then copies the parsed `body` rule inline so it survives removal of the
+ * #branch-iframe-css stylesheet on exit and can still animate back on close. margin-top/
+ * margin-bottom are added onto whatever margin the body already had, since the BE authors
+ * those values assuming an empty page.
+ */
+function applyBodyCssFromIframeContainer(cssIframeContainer, bodyMarginTopNumber, bodyMarginBottomNumber) {
+	let bodyRule = getBodyRuleFromIframeCss(cssIframeContainer);
+
+	if (!bodyRule) {
+		return;
+	}
+	const existingBodyCssText = document.body.style.cssText;
+	document.body.style.cssText = (existingBodyCssText ? existingBodyCssText + '; ' : '') + bodyRule.style.cssText;
+
+	const beMarginTop = bodyRule.style.getPropertyValue('margin-top');
+	if (beMarginTop) {
+		document.body.style.marginTop = 'calc(' + beMarginTop + ' + ' + bodyMarginTopNumber + 'px)';
+	}
+
+	const beMarginBottom = bodyRule.style.getPropertyValue('margin-bottom');
+	if (beMarginBottom) {
+		document.body.style.marginBottom = 'calc(' + beMarginBottom + ' + ' + bodyMarginBottomNumber + 'px)';
+	}
+}
+
 /***
  * @function journeys_utils.addIframeOuterCSS
  *
@@ -358,11 +407,13 @@ journeys_utils.addIframeOuterCSS = function(cssIframeContainer, metadata) {
 	var bodyMarginBottomNumber = +journeys_utils.bodyMarginBottom.slice(0, -2);
 	var bannerMarginNumber = +journeys_utils.bannerHeight.slice(0, -2);
 
-	if (cssIframeContainer) {}
+	if (cssIframeContainer) {
+		applyBodyCssFromIframeContainer(cssIframeContainer, bodyMarginTopNumber, bodyMarginBottomNumber);
+	}
 	else if (journeys_utils.position === 'top') {
 		var calculatedBodyMargin = +bannerMarginNumber + bodyMarginTopNumber;
 		document.body.style.marginTop = calculatedBodyMargin.toString() + 'px';
-	} 
+	}
 	else if (journeys_utils.position === 'bottom') {
 		var calculatedBodyMargin = +bannerMarginNumber + bodyMarginBottomNumber;
 		document.body.style.marginBottom = calculatedBodyMargin.toString() + 'px';

--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -363,11 +363,13 @@ function getBodyRuleFromIframeCss(cssIframeContainer) {
  * @param {number} bodyMarginTopNumber - margin-top (in px) the body already had before this Journey
  * @param {number} bodyMarginBottomNumber - margin-bottom (in px) the body already had before this Journey
  *
- * Parse the BE's CSS via a throwaway stylesheet
- * then copies the parsed `body` rule inline so it survives removal of the
- * #branch-iframe-css stylesheet on exit and can still animate back on close. margin-top/
- * margin-bottom are added onto whatever margin the body already had, since the BE authors
- * those values assuming an empty page.
+ * Parse the BE's CSS via a throwaway stylesheet, then move just the margin/transition
+ * declarations from the parsed `body` rule inline so they survive removal of the
+ * #branch-iframe-css stylesheet on exit and can still animate back on close. Other
+ * declarations (background, etc.) are left in the stylesheet only, same as before -
+ * they apply while the Journey is up and disappear cleanly when it's removed.
+ * margin-top/margin-bottom are added onto whatever margin the body already had, since
+ * the BE authors those values assuming an empty page.
  */
 function applyBodyCssFromIframeContainer(cssIframeContainer, bodyMarginTopNumber, bodyMarginBottomNumber) {
 	let bodyRule = getBodyRuleFromIframeCss(cssIframeContainer);
@@ -375,8 +377,15 @@ function applyBodyCssFromIframeContainer(cssIframeContainer, bodyMarginTopNumber
 	if (!bodyRule) {
 		return;
 	}
-	const existingBodyCssText = document.body.style.cssText;
-	document.body.style.cssText = (existingBodyCssText ? existingBodyCssText + '; ' : '') + bodyRule.style.cssText;
+
+	const beTransition = bodyRule.style.getPropertyValue('transition');
+	if (beTransition) {
+		document.body.style.transition = beTransition;
+	}
+	const beWebkitTransition = bodyRule.style.getPropertyValue('-webkit-transition');
+	if (beWebkitTransition) {
+		document.body.style.webkitTransition = beWebkitTransition;
+	}
 
 	const beMarginTop = bodyRule.style.getPropertyValue('margin-top');
 	if (beMarginTop) {

--- a/test/journeys_utils.js
+++ b/test/journeys_utils.js
@@ -61,11 +61,16 @@ describe('addIframeOuterCSS with a BE-supplied cssIframeContainer', function() {
     }
   });
 
-  it('should copy non-margin declarations from the BE body rule inline', function() {
+  it('should copy transition from the BE body rule inline', function() {
     const cssIframeContainer = 'body { transition: all 0.375s ease; background: black; } #branch-banner-iframe { height: 76px; }';
     journeys_utils.addIframeOuterCSS(cssIframeContainer, {});
-    assert.strictEqual(document.body.style.background, 'black', 'background copied from BE body rule');
     assert.ok(document.body.style.transition.indexOf('0.375s') !== -1, 'transition copied from BE body rule');
+  });
+
+  it('should not copy non-margin/transition declarations (e.g. background) from the BE body rule inline', function() {
+    const cssIframeContainer = 'body { background: black; }';
+    journeys_utils.addIframeOuterCSS(cssIframeContainer, {});
+    assert.strictEqual(document.body.style.background, '', 'background left in the stylesheet, not copied inline');
   });
 
   // jsdom's CSSOM implementation doesn't accept calc() as a valid margin value (real

--- a/test/journeys_utils.js
+++ b/test/journeys_utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var sinon = require('sinon');
+
 goog.require('journeys_utils');
 
 describe('getRelativeHeightValueOrFalseFromBannerHeight', function() {
@@ -44,5 +46,57 @@ describe('getRelativeHeightValueOrFalseFromBannerHeight', function() {
     const bannerHeight = '5%';
     const expected = '5';
     assert.strictEqual(journeys_utils.getRelativeHeightValueOrFalseFromBannerHeight(bannerHeight), expected, '5 from bannerHeight of 5%');
+  });
+});
+
+describe('addIframeOuterCSS with a BE-supplied cssIframeContainer', function() {
+  const assert = testUtils.unplanned();
+
+  afterEach(function() {
+    sinon.restore();
+    document.body.removeAttribute('style');
+    var iframeCss = document.getElementById('branch-iframe-css');
+    if (iframeCss) {
+      iframeCss.parentNode.removeChild(iframeCss);
+    }
+  });
+
+  it('should copy non-margin declarations from the BE body rule inline', function() {
+    const cssIframeContainer = 'body { transition: all 0.375s ease; background: black; } #branch-banner-iframe { height: 76px; }';
+    journeys_utils.addIframeOuterCSS(cssIframeContainer, {});
+    assert.strictEqual(document.body.style.background, 'black', 'background copied from BE body rule');
+    assert.ok(document.body.style.transition.indexOf('0.375s') !== -1, 'transition copied from BE body rule');
+  });
+
+  // jsdom's CSSOM implementation doesn't accept calc() as a valid margin value (real
+  // browsers do), so these spy on the setter to verify the value we attempt to set
+  // rather than reading the (jsdom-rejected) value back off document.body.style
+  it('should try to combine the BE margin-top with any pre-existing body margin-top using calc()', function() {
+    document.body.style.marginTop = '20px';
+    const marginTopSpy = sinon.spy(Object.getPrototypeOf(document.body.style), 'marginTop', ['set']);
+    const cssIframeContainer = 'body { margin-top: 75px; }';
+    journeys_utils.addIframeOuterCSS(cssIframeContainer, {});
+    assert.ok(marginTopSpy.set.calledWith('calc(75px + 20px)'), 'margin-top set to calc(BE value + pre-existing margin)');
+  });
+
+  it('should try to combine the BE margin-bottom with any pre-existing body margin-bottom using calc()', function() {
+    document.body.style.marginBottom = '10px';
+    const marginBottomSpy = sinon.spy(Object.getPrototypeOf(document.body.style), 'marginBottom', ['set']);
+    const cssIframeContainer = 'body { margin-bottom: 50px; }';
+    journeys_utils.addIframeOuterCSS(cssIframeContainer, {});
+    assert.ok(marginBottomSpy.set.calledWith('calc(50px + 10px)'), 'margin-bottom set to calc(BE value + pre-existing margin)');
+  });
+
+  it('should not set body margin when the BE CSS has no body rule', function() {
+    const cssIframeContainer = '#branch-banner-iframe { height: 76px; }';
+    journeys_utils.addIframeOuterCSS(cssIframeContainer, {});
+    assert.strictEqual(document.body.style.marginTop, '', 'no margin-top set when BE CSS has no body rule');
+    assert.strictEqual(document.body.style.marginBottom, '', 'no margin-bottom set when BE CSS has no body rule');
+  });
+
+  it('should not leave the temporary stylesheet used to parse the BE CSS in the document', function() {
+    const cssIframeContainer = 'body { margin-top: 75px; }';
+    journeys_utils.addIframeOuterCSS(cssIframeContainer, {});
+    assert.strictEqual(document.head.querySelectorAll('style').length, 1, 'only the persistent #branch-iframe-css style element remains');
   });
 });


### PR DESCRIPTION
## Description

When a Journey's iframe CSS comes from the BE (a custom `<style id="branch-iframe-css">` block embedded in the template), any `margin`/`transition` it declares on `body` lives only inside that stylesheet. `animateBannerExit` deletes the whole `#branch-iframe-css` element on close, so the body's margin snaps back to its resting value instead of animating — unlike the SDK-generated CSS path, where the margin is set inline and survives.

This moves just the `margin-top`/`margin-bottom`/`transition` declarations from the BE's parsed `body` rule inline onto `document.body.style` (via a throwaway stylesheet + the browser's own CSS parser, not regex), so they survive the stylesheet removal and combine the BE's margin value with whatever margin the body already had via `calc()` instead of clobbering it. Everything else the BE declares on `body` (background, etc.) is left in the stylesheet only — same as before, it applies while the Journey is up and disappears cleanly on close, rather than leaking permanently onto the page.

Fixes # (no ticket link provided — internal engmt-1981)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test — `addIframeOuterCSS with a BE-supplied cssIframeContainer` suite in `test/journeys_utils.js` covering: transition copied inline, non-margin/transition declarations (background) explicitly *not* copied inline, margin-top/margin-bottom combined via `calc()` with pre-existing body margin, no-op when the BE CSS has no `body` rule, and cleanup of the temporary parsing stylesheet.
- Full suite: `npx mocha` — 173 passing, 0 failing.

## JS Budget Check

| Files            | Before      | After       |
| -----------      | ----------- | ----------- |
| dist/build.js    | 165850 B    | 166801 B (+951 B) |
| dist/build.min.js| 77166 B     | 77794 B (+628 B)  |

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Mentions:

cc @BranchMetrics/saas-sdk-devs for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)