### PR TITLE
[patch] NO-TICKET: switch nix flake to prebuilt Temurin JDK 25, bump nixpkgs to 26.05

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 ## JS Budget Check
 
-Please mention the size in kb before abd after this PR
+Please mention the size in kb before and after this PR
 
 | Files            | Before      | After       | 
 | -----------      | ----------- | ----------- |

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -3,7 +3,7 @@ on: push
 
 env:
   NODE_VERSION: 24
-  JAVA_VERSION: 11
+  JAVA_VERSION: 25
   JAVA_DISTRIBUTION: 'adopt'
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774244481,
-        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
+        "lastModified": 1785133411,
+        "narHash": "sha256-Yjv0WEg39KRYS0rBdTbu6Fc/or/ihAKk13W9sQ6VWd0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,15 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         nodejs = pkgs.nodejs_24;
+        jdk = pkgs.temurin-bin-11;
       in
       {
         devShell = pkgs.mkShell {
           nativeBuildInputs = [
             nodejs
+            jdk
           ];
+          JAVA_HOME = "${jdk}";
           shellHook = ''
             if [ -f $HOME/.config/bin/setup-webstorm-sdk ] && [ -f ./.idea/workspace.xml ]; then
               $HOME/.config/bin/setup-webstorm-sdk || echo "setup-webstorm-sdk failed"

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "web-branch-deep-linking-attribution flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     utils.url = "github:numtide/flake-utils";
   };
 
@@ -11,7 +11,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         nodejs = pkgs.nodejs_24;
-        jdk = pkgs.temurin-bin-11;
+        jdk = pkgs.temurin-bin-25;
       in
       {
         devShell = pkgs.mkShell {


### PR DESCRIPTION
## Description

Adds a JDK to flake.nix and bumps to Java 25, matching CI's `JAVA_VERSION`. JDK is used to build the websdk javascript bundle

Also fixes a typo in the PR template.

## Type of change

- chore

## How Has This Been Tested?

Verified `nix develop` resolves JAVA_HOME correctly and `make all` builds successfully, producing identical dist output to before.

## JS Budget Check

No change — dist output is byte-identical before/after.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Mentions:

cc @BranchMetrics/saas-sdk-devs for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)