### PR TITLE
[minor] ENGMT-1981-1: unify body/iframe exit-animation duration, restore margin+position in sync

### DIFF
--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -426,12 +426,11 @@ function generateIframeOuterCSS(metadata) {
 
 	// If entry animation is not disabled, then animate Journey entry
 	if (!journeys_utils.entryAnimationDisabled) {
-		bodyWebkitTransitionStyle = 'body { -webkit-transition: all ' + (journeys_utils.animationSpeed * 1.5 / 1000) + 's ease; }\n';
-		document.body.style.transition = 'all 0' + (journeys_utils.animationSpeed * 1.5 / 1000) + 's ease';
+		bodyWebkitTransitionStyle = 'body { -webkit-transition: all ' + (journeys_utils.animationSpeed / 1000) + 's ease; }\n';
+		document.body.style.transition = 'all 0' + (journeys_utils.animationSpeed / 1000) + 's ease';
 		iFrameAnimationStyle = '-webkit-transition: all ' + (journeys_utils.animationSpeed / 1000) + 's ease; ' +
 						'transition: all 0' + (journeys_utils.animationSpeed / 1000) + 's ease;';
 	}
-
 
 	var css = '';
 	css += bodyWebkitTransitionStyle || '';
@@ -949,12 +948,12 @@ journeys_utils.animateBannerExit = function(banner, dismissedJourneyProgrammatic
 
 	// adds transitions for Journey exit if they don't exist
 	if (journeys_utils.entryAnimationDisabled && !journeys_utils.exitAnimationDisabled) {
-		document.body.style.transition = "all 0" + (journeys_utils.animationSpeed * 1.5 / 1000) + "s ease";
+		document.body.style.transition = "all 0" + (journeys_utils.animationSpeed / 1000) + "s ease";
 		document.getElementById('branch-banner-iframe').style.transition = "all 0" + (journeys_utils.animationSpeed / 1000) + "s ease";
 
 		// ensure that -webkit-transition styles get applied as well
 		var iFrameOutterCSSBackup = document.getElementById('branch-iframe-css').innerHTML + '\n';
-		iFrameOutterCSSBackup += 'body { -webkit-transition: all ' + (journeys_utils.animationSpeed * 1.5 / 1000) + 's ease; }\n';
+		iFrameOutterCSSBackup += 'body { -webkit-transition: all ' + (journeys_utils.animationSpeed / 1000) + 's ease; }\n';
 		iFrameOutterCSSBackup += '#branch-banner-iframe { -webkit-transition: all ' + (journeys_utils.animationSpeed / 1000) + 's ease; }\n';
 		// in order for updated styles to get applied, we have to remove all branch-iframe-css styles
 		document.getElementById('branch-iframe-css').innerHTML = "";
@@ -970,6 +969,12 @@ journeys_utils.animateBannerExit = function(banner, dismissedJourneyProgrammatic
 	}
 
 	journeys_utils.branch._publishEvent('willCloseJourney', journeys_utils.journeyLinkData);
+	if (journeys_utils.position === 'top') {
+		document.body.style.marginTop = journeys_utils.bodyMarginTop;
+	}
+	else if (journeys_utils.position === 'bottom') {
+		document.body.style.marginBottom = journeys_utils.bodyMarginBottom;
+	}
 	// removes timeout if animation is disabled or uses default timeout
 	var speedAndDelay =  journeys_utils.exitAnimationDisabled ? 0 : journeys_utils.animationSpeed + journeys_utils.animationDelay;
 	setTimeout(function() {
@@ -990,13 +995,6 @@ journeys_utils.animateBannerExit = function(banner, dismissedJourneyProgrammatic
 			journeys_utils.exitAnimationDisabledPreviously = journeys_utils.exitAnimationDisabled;
 			journeys_utils.previousPosition = journeys_utils.position;
 			journeys_utils.previousDivToInjectParents = journeys_utils.divToInjectParents;
-		}
-
-		if (journeys_utils.position === 'top') {
-			document.body.style.marginTop = journeys_utils.bodyMarginTop;
-		}
-		else if (journeys_utils.position === 'bottom') {
-			document.body.style.marginBottom = journeys_utils.bodyMarginBottom;
 		}
 
 		banner_utils.removeClass(document.body, 'branch-banner-is-active');

--- a/test/journeys_utils.js
+++ b/test/journeys_utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var sinon = require('sinon');
+
 goog.require('journeys_utils');
 
 describe('getRelativeHeightValueOrFalseFromBannerHeight', function() {
@@ -44,5 +46,91 @@ describe('getRelativeHeightValueOrFalseFromBannerHeight', function() {
     const bannerHeight = '5%';
     const expected = '5';
     assert.strictEqual(journeys_utils.getRelativeHeightValueOrFalseFromBannerHeight(bannerHeight), expected, '5 from bannerHeight of 5%');
+  });
+});
+
+describe('addIframeOuterCSS generated CSS (no BE-supplied cssIframeContainer)', function() {
+  const assert = testUtils.unplanned();
+
+  afterEach(function() {
+    var existing = document.getElementById('branch-iframe-css');
+    if (existing && existing.parentNode) {
+      existing.parentNode.removeChild(existing);
+    }
+    document.body.removeAttribute('style');
+  });
+
+  it('should give body the same transition duration as the iframe', function() {
+    journeys_utils.position = 'top';
+    journeys_utils.bannerHeight = '76px';
+    journeys_utils.isDesktopJourney = false;
+    journeys_utils.entryAnimationDisabled = false;
+    journeys_utils.animationSpeed = 200;
+    journeys_utils.divToInjectParents = [];
+
+    journeys_utils.addIframeOuterCSS(undefined, {});
+
+    var expectedDurationSeconds = journeys_utils.animationSpeed / 1000;
+    assert.strictEqual(document.body.style.transition, 'all 0' + expectedDurationSeconds + 's ease');
+
+    var css = document.getElementById('branch-iframe-css').innerHTML;
+    assert.ok(
+      css.indexOf('body { -webkit-transition: all ' + expectedDurationSeconds + 's ease; }') !== -1,
+      'body -webkit-transition duration should match the iframe duration'
+    );
+    assert.ok(
+      css.indexOf('-webkit-transition: all ' + expectedDurationSeconds + 's ease; transition: all 0' + expectedDurationSeconds + 's ease;') !== -1,
+      'iframe rule should use the same duration as body'
+    );
+  });
+});
+
+describe('animateBannerExit margin/position restore timing', function() {
+  const assert = testUtils.unplanned();
+  var clock;
+  var banner;
+
+  beforeEach(function() {
+    clock = sinon.useFakeTimers();
+    banner = document.createElement('div');
+    document.body.appendChild(banner);
+
+    journeys_utils.branch = { _publishEvent: sinon.stub() };
+    journeys_utils.journeyLinkData = {};
+    journeys_utils.divToInjectParents = [];
+    journeys_utils.position = 'top';
+    journeys_utils.bannerHeight = '76px';
+    journeys_utils.bodyMarginTop = '10px';
+    journeys_utils.exitAnimationDisabled = false;
+    journeys_utils.entryAnimationDisabled = false;
+    journeys_utils.animationSpeed = 250;
+    journeys_utils.animationDelay = 20;
+    journeys_utils.isSafeAreaEnabled = false;
+    document.body.style.marginTop = '86px';
+  });
+
+  afterEach(function() {
+    clock.restore();
+    sinon.restore();
+    if (banner.parentNode) {
+      banner.parentNode.removeChild(banner);
+    }
+    document.body.removeAttribute('style');
+    document.body.className = '';
+  });
+
+  it('restores body margin and banner position synchronously, before the delayed teardown', function() {
+    journeys_utils.animateBannerExit(banner);
+
+    // synchronous: happens immediately, not inside the delayed setTimeout
+    assert.strictEqual(banner.style.top, '-' + journeys_utils.bannerHeight);
+    assert.strictEqual(document.body.style.marginTop, journeys_utils.bodyMarginTop);
+
+    // teardown (removal) is still deferred at this point
+    assert.strictEqual(document.body.contains(banner), true);
+
+    clock.tick(journeys_utils.animationSpeed + journeys_utils.animationDelay);
+
+    assert.strictEqual(document.body.contains(banner), false);
   });
 });


### PR DESCRIPTION
## Description

Journey exit animation for the SDK-generated (non-BE) CSS path had two related timing bugs:

- Body's transition duration was hardcoded to `animationSpeed * 1.5` while the iframe's was `animationSpeed` — but the exit teardown timer (`speedAndDelay = animationSpeed + animationDelay`) only accounted for the iframe's (shorter) duration. Body's margin transition was getting cut off partway through before the DOM/stylesheet got torn down.
- `animateBannerExit` was resetting body margin *inside* the delayed `setTimeout` teardown block, instead of alongside the banner-position reset — so margin and position weren't animating back in sync.

This unifies both transitions to `animationSpeed`, and moves the margin restore up to right after the `willCloseJourney` event, so margin and position animate back together, finishing right around when the (already correctly-delayed) teardown timer fires.

This is separate from #1147 (BE-supplied CSS path) — that's a different, unrelated code path.

Fixes ENGMT-1981 (partial — non-BE path only)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test

Added two tests in `test/journeys_utils.js`:
- `generateIframeOuterCSS`/`addIframeOuterCSS` now gives body the same transition duration as the iframe (regression guard against the old `* 1.5` multiplier).
- `animateBannerExit` restores body margin and banner position synchronously, before the delayed teardown fires (verified via sinon fake timers).

Full suite (169 passing, 6 pending) and lint pass locally.

## JS Budget Check

| Files             | Before  | After   |
| ----------------- | ------- | ------- |
| dist/build.js      | 165850 B | 165824 B |
| dist/build.min.js  | 77166 B  | 77162 B  |

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Mentions:
cc @BranchMetrics/saas-sdk-devs for visibility.